### PR TITLE
Labeled tuples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/mocha": "^8.2.0",
         "@types/node": "^14.14.31",
         "@types/sinon": "^10.0.0",
+        "@types/sinon-chai": "^3.2.5",
         "benchmark": "^2.1.4",
         "catharsis": "^0.9.0",
         "chai": "^4.3.0",
@@ -26,6 +27,7 @@
         "rollup": "^2.39.0",
         "semantic-release": "^17.4.3",
         "sinon": "^10.0.0",
+        "sinon-chai": "^3.7.0",
         "ts-node": "^9.1.1",
         "ts-standard": "^10.0.0",
         "typedoc": "^0.20.24",
@@ -1191,6 +1193,16 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/fake-timers": "^7.0.4"
+      }
+    },
+    "node_modules/@types/sinon-chai": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.5.tgz",
+      "integrity": "sha512-bKQqIpew7mmIGNRlxW6Zli/QVyc3zikpGzCa797B/tRnD9OtHvZ/ts8sYXV+Ilj9u3QRaUEM8xrjgd1gwm1BpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
       }
     },
     "node_modules/@types/sinon/node_modules/@sinonjs/fake-timers": {
@@ -10042,6 +10054,16 @@
         "supports-color": "^7.1.0"
       }
     },
+    "node_modules/sinon-chai": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
+      "dev": true,
+      "peerDependencies": {
+        "chai": "^4.0.0",
+        "sinon": ">=4.0.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -12343,6 +12365,16 @@
             "@sinonjs/commons": "^1.7.0"
           }
         }
+      }
+    },
+    "@types/sinon-chai": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.5.tgz",
+      "integrity": "sha512-bKQqIpew7mmIGNRlxW6Zli/QVyc3zikpGzCa797B/tRnD9OtHvZ/ts8sYXV+Ilj9u3QRaUEM8xrjgd1gwm1BpQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
       }
     },
     "@typescript-eslint/eslint-plugin": {
@@ -19195,6 +19227,13 @@
         "nise": "^4.1.0",
         "supports-color": "^7.1.0"
       }
+    },
+    "sinon-chai": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
+      "dev": true,
+      "requires": {}
     },
     "slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/mocha": "^8.2.0",
     "@types/node": "^14.14.31",
     "@types/sinon": "^10.0.0",
+    "@types/sinon-chai": "^3.2.5",
     "benchmark": "^2.1.4",
     "catharsis": "^0.9.0",
     "chai": "^4.3.0",
@@ -47,6 +48,7 @@
     "rollup": "^2.39.0",
     "semantic-release": "^17.4.3",
     "sinon": "^10.0.0",
+    "sinon-chai": "^3.7.0",
     "ts-node": "^9.1.1",
     "ts-standard": "^10.0.0",
     "typedoc": "^0.20.24",
@@ -93,5 +95,7 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
   }
 }

--- a/src/assertTypes.ts
+++ b/src/assertTypes.ts
@@ -13,18 +13,27 @@ export function assertTerminal (result?: IntermediateResult): TerminalResult {
   return result
 }
 
-export function assertKeyValueOrTerminal (result: IntermediateResult): KeyValueResult | TerminalResult {
-  if (result.type === 'JsdocTypeKeyValue' && 'value' in result) {
-    return result
+export function assertPlainKeyValueOrTerminal (result: IntermediateResult): KeyValueResult | TerminalResult {
+  if (result.type === 'JsdocTypeKeyValue') {
+    return assertPlainKeyValue(result)
   }
   return assertTerminal(result)
 }
 
-export function assertKeyValueOrName (result: IntermediateResult): KeyValueResult | NameResult {
-  if (result.type === 'JsdocTypeKeyValue' && 'value' in result) {
+export function assertPlainKeyValueOrName (result: IntermediateResult): KeyValueResult | NameResult {
+  if (result.type === 'JsdocTypeName') {
     return result
-  } else if (result.type !== 'JsdocTypeName') {
-    throw new UnexpectedTypeError(result)
+  }
+  return assertPlainKeyValue(result)
+}
+
+export function assertPlainKeyValue (result: IntermediateResult): KeyValueResult {
+  if (!isPlainKeyValue(result)) {
+    if (result.type === 'JsdocTypeKeyValue') {
+      throw new UnexpectedTypeError(result, 'Expecting no left side expression.')
+    } else {
+      throw new UnexpectedTypeError(result)
+    }
   }
   return result
 }
@@ -40,4 +49,8 @@ export function assertNumberOrVariadicName (result: IntermediateResult): NumberR
     throw new UnexpectedTypeError(result)
   }
   return result
+}
+
+export function isPlainKeyValue (result: IntermediateResult): result is KeyValueResult {
+  return result.type === 'JsdocTypeKeyValue' && !result.meta.hasLeftSideExpression
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -42,8 +42,12 @@ export class EarlyEndOfParseError extends Error {
 }
 
 export class UnexpectedTypeError extends Error {
-  constructor (result: IntermediateResult) {
-    super(`Unexpected type: '${result.type}'`)
+  constructor (result: IntermediateResult, message?: string) {
+    let error = `Unexpected type: '${result.type}'.`
+    if (message !== undefined) {
+      error += ` Message: ${message}`
+    }
+    super(error)
 
     Object.setPrototypeOf(this, UnexpectedTypeError.prototype)
   }

--- a/src/parslets/ArrowFunctionParslet.ts
+++ b/src/parslets/ArrowFunctionParslet.ts
@@ -2,7 +2,7 @@ import { InfixParslet } from './Parslet'
 import { TokenType } from '../lexer/Token'
 import { Precedence } from '../Precedence'
 import { BaseFunctionParslet } from './BaseFunctionParslet'
-import { assertKeyValueOrName } from '../assertTypes'
+import { assertPlainKeyValueOrName } from '../assertTypes'
 import { Parser } from '../Parser'
 import { FunctionResult } from '../result/TerminalResult'
 import { IntermediateResult } from '../result/IntermediateResult'
@@ -21,7 +21,7 @@ export class ArrowFunctionParslet extends BaseFunctionParslet implements InfixPa
 
     return {
       type: 'JsdocTypeFunction',
-      parameters: this.getParameters(left).map(assertKeyValueOrName),
+      parameters: this.getParameters(left).map(assertPlainKeyValueOrName),
       arrow: true,
       parenthesis: true,
       returnType: parser.parseType(Precedence.ALL)

--- a/src/parslets/BaseFunctionParslet.ts
+++ b/src/parslets/BaseFunctionParslet.ts
@@ -1,5 +1,5 @@
 import { KeyValueResult, NonTerminalResult } from '../result/NonTerminalResult'
-import { assertKeyValueOrTerminal } from '../assertTypes'
+import { assertPlainKeyValueOrTerminal } from '../assertTypes'
 import { UnexpectedTypeError } from '../errors'
 import { IntermediateResult } from '../result/IntermediateResult'
 import { TerminalResult } from '../result/TerminalResult'
@@ -15,7 +15,7 @@ export class BaseFunctionParslet {
       throw new UnexpectedTypeError(value)
     }
 
-    return parameters.map(p => assertKeyValueOrTerminal(p))
+    return parameters.map(p => assertPlainKeyValueOrTerminal(p))
   }
 
   protected getUnnamedParameters (value: IntermediateResult): TerminalResult[] {

--- a/src/parslets/FunctionParslet.ts
+++ b/src/parslets/FunctionParslet.ts
@@ -61,7 +61,7 @@ export class FunctionParslet extends BaseFunctionParslet implements PrefixParsle
     } else {
       result.parameters = this.getParameters(value)
       for (const p of result.parameters) {
-        if (p.type === 'JsdocTypeKeyValue' && (!this.allowNamedParameters.includes(p.value) || p.meta.quote !== undefined)) {
+        if (p.type === 'JsdocTypeKeyValue' && (!this.allowNamedParameters.includes(p.key) || p.meta.quote !== undefined)) {
           throw new Error(`only allowed named parameters are ${this.allowNamedParameters.join(',')} but got ${p.type}`)
         }
       }

--- a/src/parslets/KeyValueParslet.ts
+++ b/src/parslets/KeyValueParslet.ts
@@ -56,12 +56,13 @@ export class KeyValueParslet implements InfixParslet {
 
       return {
         type: 'JsdocTypeKeyValue',
-        value: left.value.toString(),
+        key: left.value.toString(),
         right: parser.parseType(Precedence.KEY_VALUE),
         optional: optional,
         readonly: readonlyProperty,
         meta: {
-          quote
+          quote,
+          hasLeftSideExpression: false
         }
       }
     } else {
@@ -74,7 +75,10 @@ export class KeyValueParslet implements InfixParslet {
       return {
         type: 'JsdocTypeKeyValue',
         left: assertTerminal(left),
-        right: parser.parseType(Precedence.KEY_VALUE)
+        right: parser.parseType(Precedence.KEY_VALUE),
+        meta: {
+          hasLeftSideExpression: true
+        }
       }
     }
   }

--- a/src/parslets/ObjectParslet.ts
+++ b/src/parslets/ObjectParslet.ts
@@ -54,12 +54,13 @@ export class ObjectParslet implements PrefixParslet {
 
           result.elements.push({
             type: 'JsdocTypeKeyValue',
-            value: field.value.toString(),
+            key: field.value.toString(),
             right: undefined,
             optional: optional,
             readonly: false,
             meta: {
-              quote
+              quote,
+              hasLeftSideExpression: false
             }
           })
         } else if (field.type === 'JsdocTypeKeyValue') {

--- a/src/parslets/ParameterListParslet.ts
+++ b/src/parslets/ParameterListParslet.ts
@@ -1,7 +1,7 @@
 import { InfixParslet } from './Parslet'
 import { TokenType } from '../lexer/Token'
 import { Precedence } from '../Precedence'
-import { assertKeyValueOrTerminal } from '../assertTypes'
+import { assertPlainKeyValueOrTerminal } from '../assertTypes'
 import { NoParsletFoundError } from '../errors'
 import { Parser } from '../Parser'
 import { IntermediateResult, ParameterList } from '../result/IntermediateResult'
@@ -29,13 +29,13 @@ export class ParameterListParslet implements InfixParslet {
 
   parseInfix (parser: Parser, left: IntermediateResult): ParameterList {
     const elements: Array<TerminalResult|KeyValueResult> = [
-      assertKeyValueOrTerminal(left)
+      assertPlainKeyValueOrTerminal(left)
     ]
     parser.consume(',')
     do {
       try {
         const next = parser.parseIntermediateType(Precedence.PARAMETER_LIST)
-        elements.push(assertKeyValueOrTerminal(next))
+        elements.push(assertPlainKeyValueOrTerminal(next))
       } catch (e) {
         if (this.allowTrailingComma && e instanceof NoParsletFoundError) {
           break

--- a/src/parslets/ParenthesisParslet.ts
+++ b/src/parslets/ParenthesisParslet.ts
@@ -1,7 +1,7 @@
 import { PrefixParslet } from './Parslet'
 import { TokenType } from '../lexer/Token'
 import { Precedence } from '../Precedence'
-import { assertTerminal } from '../assertTypes'
+import { assertTerminal, isPlainKeyValue } from '../assertTypes'
 import { Parser } from '../Parser'
 import { ParenthesisResult } from '../result/TerminalResult'
 import { ParameterList } from '../result/IntermediateResult'
@@ -29,7 +29,7 @@ export class ParenthesisParslet implements PrefixParslet {
     }
     if (result.type === 'JsdocTypeParameterList') {
       return result
-    } else if (result.type === 'JsdocTypeKeyValue' && 'value' in result) {
+    } else if (result.type === 'JsdocTypeKeyValue' && isPlainKeyValue(result)) {
       return {
         type: 'JsdocTypeParameterList',
         elements: [result]

--- a/src/result/NonTerminalResult.ts
+++ b/src/result/NonTerminalResult.ts
@@ -16,12 +16,13 @@ export type NonTerminalResult =
  */
 export interface KeyValueResult {
   type: 'JsdocTypeKeyValue'
-  value: string
+  key: string
   right: TerminalResult | undefined
   optional: boolean
   readonly: boolean
   meta: {
     quote: QuoteStyle | undefined
+    hasLeftSideExpression: false
   }
 }
 
@@ -34,6 +35,9 @@ export interface JsdocObjectKeyValueResult {
   type: 'JsdocTypeKeyValue'
   left: TerminalResult
   right: TerminalResult
+  meta: {
+    hasLeftSideExpression: true
+  }
 }
 
 export interface PropertyResult {

--- a/src/result/TerminalResult.ts
+++ b/src/result/TerminalResult.ts
@@ -239,7 +239,7 @@ export interface ImportResult {
  */
 export interface TupleResult {
   type: 'JsdocTypeTuple'
-  elements: TerminalResult[]
+  elements: TerminalResult[]|KeyValueResult[]
 }
 
 /**

--- a/src/transforms/catharsisTransform.ts
+++ b/src/transforms/catharsisTransform.ts
@@ -1,5 +1,5 @@
 import { extractSpecialParams, notAvailableTransform, transform, TransformRules } from './transform'
-import { assertTerminal } from '../assertTypes'
+import { assertTerminal, isPlainKeyValue } from '../assertTypes'
 import { TerminalResult } from '../result/TerminalResult'
 import { quote } from './stringify'
 
@@ -239,10 +239,10 @@ const catharsisTransformRules: TransformRules<CatharsisParseResult> = {
   }),
 
   JsdocTypeKeyValue: (result, transform) => {
-    if ('value' in result) {
+    if (isPlainKeyValue(result)) {
       return {
         type: 'FieldType',
-        key: makeName(quote(result.value, result.meta.quote)),
+        key: makeName(quote(result.key, result.meta.quote)),
         value: result.right === undefined ? undefined : transform(result.right)
       }
     } else {

--- a/src/transforms/identityTransformRules.ts
+++ b/src/transforms/identityTransformRules.ts
@@ -13,6 +13,7 @@ import {
   VariadicResult,
   NumberResult
 } from '../result/TerminalResult'
+import { isPlainKeyValue } from '../assertTypes'
 
 export function identityTransformRules (): TransformRules<NonTerminalResult> {
   return {
@@ -89,10 +90,10 @@ export function identityTransformRules (): TransformRules<NonTerminalResult> {
     JsdocTypeSpecialNamePath: result => result,
 
     JsdocTypeKeyValue: (result, transform) => {
-      if ('value' in result) {
+      if (isPlainKeyValue(result)) {
         return {
           type: 'JsdocTypeKeyValue',
-          value: result.value,
+          key: result.key,
           right: result.right === undefined ? undefined : transform(result.right) as TerminalResult,
           optional: result.optional,
           readonly: result.readonly,
@@ -102,7 +103,8 @@ export function identityTransformRules (): TransformRules<NonTerminalResult> {
         return {
           type: 'JsdocTypeKeyValue',
           left: transform(result.left) as TerminalResult,
-          right: transform(result.right) as TerminalResult
+          right: transform(result.right) as TerminalResult,
+          meta: result.meta
         }
       }
     },

--- a/src/transforms/identityTransformRules.ts
+++ b/src/transforms/identityTransformRules.ts
@@ -138,7 +138,7 @@ export function identityTransformRules (): TransformRules<NonTerminalResult> {
 
     JsdocTypeTuple: (result, transform) => ({
       type: 'JsdocTypeTuple',
-      elements: result.elements.map(transform) as TerminalResult[]
+      elements: (result.elements as NonTerminalResult[]).map(transform) as TerminalResult[]|KeyValueResult[]
     }),
 
     JsdocTypeName: result => result,

--- a/src/transforms/jtpTransform.ts
+++ b/src/transforms/jtpTransform.ts
@@ -1,6 +1,7 @@
 import { extractSpecialParams, notAvailableTransform, transform, TransformRules } from './transform'
 import { QuoteStyle, TerminalResult } from '../result/TerminalResult'
-import { assertTerminal } from '../assertTypes'
+import { assertTerminal, isPlainKeyValue } from '../assertTypes'
+import { NonTerminalResult } from '../result/NonTerminalResult'
 
 export type JtpResult =
   JtpNameResult
@@ -307,7 +308,7 @@ const jtpRules: TransformRules<JtpResult> = {
           }
           return {
             type: 'NAMED_PARAMETER',
-            name: param.value,
+            name: param.key,
             typeName: transform(param.right)
           }
         } else {
@@ -356,14 +357,14 @@ const jtpRules: TransformRules<JtpResult> = {
   },
 
   JsdocTypeKeyValue: (result, transform) => {
-    if ('left' in result) {
+    if (!isPlainKeyValue(result)) {
       throw new Error('Keys may not be typed in jsdoctypeparser.')
     }
 
     if (result.right === undefined) {
       return {
         type: 'RECORD_ENTRY',
-        key: result.value.toString(),
+        key: result.key.toString(),
         quoteStyle: getQuoteStyle(result.meta.quote),
         value: null,
         readonly: false
@@ -383,7 +384,7 @@ const jtpRules: TransformRules<JtpResult> = {
 
     return {
       type: 'RECORD_ENTRY',
-      key: result.value.toString(),
+      key: result.key.toString(),
       quoteStyle: getQuoteStyle(result.meta.quote),
       value: right,
       readonly: false

--- a/src/transforms/jtpTransform.ts
+++ b/src/transforms/jtpTransform.ts
@@ -270,7 +270,7 @@ const jtpRules: TransformRules<JtpResult> = {
 
   JsdocTypeTuple: (result, transform) => ({
     type: 'TUPLE',
-    entries: result.elements.map(transform)
+    entries: (result.elements as NonTerminalResult[]).map(transform)
   }),
 
   JsdocTypeKeyof: (result, transform) => ({

--- a/src/transforms/stringify.ts
+++ b/src/transforms/stringify.ts
@@ -1,6 +1,7 @@
 import { transform, TransformRules } from './transform'
 import { NonTerminalResult } from '../result/NonTerminalResult'
 import { TerminalResult } from '../result/TerminalResult'
+import { isPlainKeyValue } from '../assertTypes'
 
 function applyPosition (position: 'prefix' | 'suffix', target: string, value: string): string {
   return position === 'prefix' ? value + target : target + value
@@ -76,12 +77,12 @@ export function stringifyRules (): TransformRules<string> {
     JsdocTypeImport: (result, transform) => `import(${transform(result.element)})`,
 
     JsdocTypeKeyValue: (result, transform) => {
-      if ('value' in result) {
+      if (isPlainKeyValue(result)) {
         let text = ''
         if (result.readonly) {
           text += 'readonly '
         }
-        text += quote(result.value, result.meta.quote)
+        text += quote(result.key, result.meta.quote)
         if (result.optional) {
           text += '?'
         }

--- a/src/transforms/stringify.ts
+++ b/src/transforms/stringify.ts
@@ -45,7 +45,7 @@ export function stringifyRules (): TransformRules<string> {
 
     JsdocTypeName: result => result.value,
 
-    JsdocTypeTuple: (result, transform) => `[${result.elements.map(transform).join(', ')}]`,
+    JsdocTypeTuple: (result, transform) => `[${(result.elements as NonTerminalResult[]).map(transform).join(', ')}]`,
 
     JsdocTypeVariadic: (result, transform) => result.meta.position === undefined
       ? '...'

--- a/src/transforms/transform.ts
+++ b/src/transforms/transform.ts
@@ -35,9 +35,9 @@ export function extractSpecialParams (source: FunctionResult): SpecialFunctionPa
 
   for (const param of source.parameters) {
     if (param.type === 'JsdocTypeKeyValue' && param.meta.quote === undefined) {
-      if (param.value === 'this') {
+      if (param.key === 'this') {
         result.this = param.right
-      } else if (param.value === 'new') {
+      } else if (param.key === 'new') {
         result.new = param.right
       } else {
         result.params.push(param)

--- a/test/fixtures/catharsis/functionType.spec.ts
+++ b/test/fixtures/catharsis/functionType.spec.ts
@@ -240,11 +240,12 @@ describe('catharsis function type tests', () => {
       expected: {
         parameters: [
           {
-            value: 'this',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             type: 'JsdocTypeKeyValue',
+            key: 'this',
             readonly: false,
             optional: false,
             right: {
@@ -297,11 +298,12 @@ describe('catharsis function type tests', () => {
       expected: {
         parameters: [
           {
-            value: 'this',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             type: 'JsdocTypeKeyValue',
+            key: 'this',
             readonly: false,
             optional: false,
             right: {
@@ -362,9 +364,10 @@ describe('catharsis function type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'new',
+            key: 'new',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               left: {
@@ -417,12 +420,13 @@ describe('catharsis function type tests', () => {
         parameters: [
           {
             type: 'JsdocTypeKeyValue',
+            key: 'new',
             readonly: false,
             optional: false,
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
-            value: 'new',
             right: {
               left: {
                 left: {
@@ -480,9 +484,10 @@ describe('catharsis function type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'new',
+            key: 'new',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               left: {
@@ -509,9 +514,10 @@ describe('catharsis function type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'this',
+            key: 'this',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               left: {
@@ -713,9 +719,10 @@ describe('catharsis function type tests', () => {
               type: 'JsdocTypeKeyValue',
               readonly: false,
               optional: false,
-              value: 'new',
+              key: 'new',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 type: 'JsdocTypeName',
@@ -726,9 +733,10 @@ describe('catharsis function type tests', () => {
               type: 'JsdocTypeKeyValue',
               readonly: false,
               optional: false,
-              value: 'this',
+              key: 'this',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 type: 'JsdocTypeName',
@@ -802,9 +810,10 @@ describe('catharsis function type tests', () => {
               type: 'JsdocTypeKeyValue',
               readonly: false,
               optional: false,
-              value: 'new',
+              key: 'new',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 type: 'JsdocTypeName',
@@ -815,9 +824,10 @@ describe('catharsis function type tests', () => {
               type: 'JsdocTypeKeyValue',
               readonly: false,
               optional: false,
-              value: 'this',
+              key: 'this',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 type: 'JsdocTypeName',
@@ -1063,9 +1073,10 @@ describe('catharsis function type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'this',
+            key: 'this',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -1121,9 +1132,10 @@ describe('catharsis function type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'this',
+            key: 'this',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               element: {
@@ -1192,9 +1204,10 @@ describe('catharsis function type tests', () => {
               type: 'JsdocTypeKeyValue',
               readonly: false,
               optional: false,
-              value: 'new',
+              key: 'new',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 type: 'JsdocTypeName',
@@ -1226,9 +1239,10 @@ describe('catharsis function type tests', () => {
               type: 'JsdocTypeKeyValue',
               readonly: false,
               optional: false,
-              value: 'new',
+              key: 'new',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 type: 'JsdocTypeName',
@@ -1287,9 +1301,10 @@ describe('catharsis function type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'new',
+            key: 'new',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -1414,9 +1429,10 @@ describe('catharsis function type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'this',
+            key: 'this',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',

--- a/test/fixtures/catharsis/jsdoc.spec.ts
+++ b/test/fixtures/catharsis/jsdoc.spec.ts
@@ -800,6 +800,9 @@ describe('catharsis jsdoc tests', () => {
             right: {
               type: 'JsdocTypeName',
               value: 'number'
+            },
+            meta: {
+              hasLeftSideExpression: true
             }
           }
         ]
@@ -855,6 +858,9 @@ describe('catharsis jsdoc tests', () => {
             right: {
               type: 'JsdocTypeName',
               value: 'number'
+            },
+            meta: {
+              hasLeftSideExpression: true
             }
           }
         ]
@@ -889,9 +895,10 @@ describe('catharsis jsdoc tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'undefinedHTML',
+            key: 'undefinedHTML',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeParenthesis',
@@ -943,9 +950,10 @@ describe('catharsis jsdoc tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'foo',
+            key: 'foo',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeFunction',
@@ -987,9 +995,10 @@ describe('catharsis jsdoc tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'foo',
+            key: 'foo',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeFunction',
@@ -1059,9 +1068,10 @@ describe('catharsis jsdoc tests', () => {
               type: 'JsdocTypeKeyValue',
               readonly: false,
               optional: false,
-              value: 'this',
+              key: 'this',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 left: {

--- a/test/fixtures/catharsis/recordType.spec.ts
+++ b/test/fixtures/catharsis/recordType.spec.ts
@@ -42,9 +42,10 @@ describe('catharsis record type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'myNum',
+            key: 'myNum',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -86,9 +87,10 @@ describe('catharsis record type tests', () => {
               type: 'JsdocTypeKeyValue',
               readonly: false,
               optional: false,
-              value: 'myNum',
+              key: 'myNum',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 type: 'JsdocTypeName',
@@ -135,9 +137,10 @@ describe('catharsis record type tests', () => {
               type: 'JsdocTypeKeyValue',
               readonly: false,
               optional: false,
-              value: 'myNum',
+              key: 'myNum',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 type: 'JsdocTypeName',
@@ -183,9 +186,10 @@ describe('catharsis record type tests', () => {
               type: 'JsdocTypeKeyValue',
               readonly: false,
               optional: false,
-              value: 'myNum',
+              key: 'myNum',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 type: 'JsdocTypeName',
@@ -231,9 +235,10 @@ describe('catharsis record type tests', () => {
               type: 'JsdocTypeKeyValue',
               readonly: false,
               optional: false,
-              value: 'myNum',
+              key: 'myNum',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 type: 'JsdocTypeName',
@@ -277,9 +282,10 @@ describe('catharsis record type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'myNum',
+            key: 'myNum',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -289,11 +295,12 @@ describe('catharsis record type tests', () => {
           {
             type: 'JsdocTypeKeyValue',
             readonly: false,
-            value: 'myObject',
+            key: 'myObject',
             right: undefined,
             optional: false,
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             }
           }
         ]
@@ -329,9 +336,10 @@ describe('catharsis record type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'myNum',
+            key: 'myNum',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -341,10 +349,11 @@ describe('catharsis record type tests', () => {
           {
             type: 'JsdocTypeKeyValue',
             readonly: false,
-            value: 'myObject',
+            key: 'myObject',
             optional: false,
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -384,9 +393,10 @@ describe('catharsis record type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'myArray',
+            key: 'myArray',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeGeneric',
@@ -440,9 +450,10 @@ describe('catharsis record type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'myKey',
+            key: 'myKey',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeParenthesis',
@@ -498,9 +509,10 @@ describe('catharsis record type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'continue',
+            key: 'continue',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -540,9 +552,10 @@ describe('catharsis record type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'class',
+            key: 'class',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -582,9 +595,10 @@ describe('catharsis record type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'true',
+            key: 'true',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -624,9 +638,10 @@ describe('catharsis record type tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: '0',
+            key: '0',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',

--- a/test/fixtures/catharsis/typeApplication.spec.ts
+++ b/test/fixtures/catharsis/typeApplication.spec.ts
@@ -193,9 +193,10 @@ describe('catharsis type application tests', () => {
                           type: 'JsdocTypeKeyValue',
                           readonly: false,
                           optional: false,
-                          value: 'myKey',
+                          key: 'myKey',
                           meta: {
-                            quote: undefined
+                            quote: undefined,
+                            hasLeftSideExpression: false
                           },
                           right: {
                             type: 'JsdocTypeName',
@@ -237,9 +238,10 @@ describe('catharsis type application tests', () => {
                       type: 'JsdocTypeKeyValue',
                       readonly: false,
                       optional: false,
-                      value: 'new',
+                      key: 'new',
                       meta: {
-                        quote: undefined
+                        quote: undefined,
+                        hasLeftSideExpression: false
                       },
                       right: {
                         type: 'JsdocTypeName',
@@ -300,11 +302,12 @@ describe('catharsis type application tests', () => {
               {
                 type: 'JsdocTypeKeyValue',
                 readonly: false,
-                value: 'length',
+                key: 'length',
                 right: undefined,
                 optional: false,
                 meta: {
-                  quote: undefined
+                  quote: undefined,
+                  hasLeftSideExpression: false
                 }
               }
             ]

--- a/test/fixtures/typescript/arrowFunction.spec.ts
+++ b/test/fixtures/typescript/arrowFunction.spec.ts
@@ -11,9 +11,10 @@ describe('typescript arrow function tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'x',
+            key: 'x',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeAny'
@@ -52,9 +53,10 @@ describe('typescript arrow function tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'x',
+            key: 'x',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -95,9 +97,10 @@ describe('typescript arrow function tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'x',
+            key: 'x',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -108,9 +111,10 @@ describe('typescript arrow function tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'y',
+            key: 'y',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -121,9 +125,10 @@ describe('typescript arrow function tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'z',
+            key: 'z',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -269,9 +274,10 @@ describe('typescript arrow function tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'arrow',
+            key: 'arrow',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -282,9 +288,10 @@ describe('typescript arrow function tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'with',
+            key: 'with',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -431,9 +438,10 @@ describe('typescript arrow function tests', () => {
             type: 'JsdocTypeKeyValue',
             readonly: false,
             optional: false,
-            value: 'a',
+            key: 'a',
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             },
             right: {
               type: 'JsdocTypeName',
@@ -448,9 +456,10 @@ describe('typescript arrow function tests', () => {
               type: 'JsdocTypeKeyValue',
               readonly: false,
               optional: false,
-              value: 'b',
+              key: 'b',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 type: 'JsdocTypeName',

--- a/test/fixtures/typescript/intersection.spec.ts
+++ b/test/fixtures/typescript/intersection.spec.ts
@@ -160,9 +160,10 @@ describe('typescript intersection tests', () => {
                 type: 'JsdocTypeKeyValue',
                 readonly: false,
                 optional: false,
-                value: 'a',
+                key: 'a',
                 meta: {
-                  quote: undefined
+                  quote: undefined,
+                  hasLeftSideExpression: false
                 },
                 right: {
                   type: 'JsdocTypeName',

--- a/test/fixtures/typescript/objects.spec.ts
+++ b/test/fixtures/typescript/objects.spec.ts
@@ -16,9 +16,10 @@ describe('typescript objects tests', () => {
             {
               type: 'JsdocTypeKeyValue',
               readonly: false,
-              value: 'object',
+              key: 'object',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 type: 'JsdocTypeName',
@@ -29,9 +30,10 @@ describe('typescript objects tests', () => {
             {
               type: 'JsdocTypeKeyValue',
               readonly: false,
-              value: 'key',
+              key: 'key',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 type: 'JsdocTypeName',
@@ -62,14 +64,18 @@ describe('typescript objects tests', () => {
               right: {
                 type: 'JsdocTypeName',
                 value: 'string'
+              },
+              meta: {
+                hasLeftSideExpression: true
               }
             },
             {
               type: 'JsdocTypeKeyValue',
               readonly: false,
-              value: 'key',
+              key: 'key',
               meta: {
-                quote: undefined
+                quote: undefined,
+                hasLeftSideExpression: false
               },
               right: {
                 type: 'JsdocTypeName',
@@ -110,7 +116,7 @@ describe('typescript objects tests', () => {
           {
             type: 'JsdocTypeKeyValue',
             readonly: false,
-            value: 'message',
+            key: 'message',
             right: {
               type: 'JsdocTypeUnion',
               elements: [
@@ -125,7 +131,8 @@ describe('typescript objects tests', () => {
             },
             optional: false,
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             }
           }
         ]
@@ -161,11 +168,12 @@ describe('typescript objects tests', () => {
           {
             type: 'JsdocTypeKeyValue',
             readonly: false,
-            value: 'message',
+            key: 'message',
             right: undefined,
             optional: true,
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             }
           }
         ]

--- a/test/fixtures/typescript/readonly.ts
+++ b/test/fixtures/typescript/readonly.ts
@@ -21,7 +21,7 @@ describe('typescript readonly tests', () => {
         elements: [
           {
             type: 'JsdocTypeKeyValue',
-            value: 'x',
+            key: 'x',
             right: {
               type: 'JsdocTypeName',
               value: 'number'
@@ -29,7 +29,8 @@ describe('typescript readonly tests', () => {
             optional: false,
             readonly: true,
             meta: {
-              quote: undefined
+              quote: undefined,
+              hasLeftSideExpression: false
             }
           }
         ]

--- a/test/fixtures/typescript/tuple.spec.ts
+++ b/test/fixtures/typescript/tuple.spec.ts
@@ -594,4 +594,77 @@ describe('typescript tuple tests', () => {
       }
     })
   })
+
+  describe('labeled tuple with one element', () => {
+    testFixture({
+      input: '[a: string]',
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeTuple',
+        elements: [
+          {
+            type: 'JsdocTypeKeyValue',
+            key: 'a',
+            optional: false,
+            readonly: false,
+            meta: {
+              quote: undefined,
+              hasLeftSideExpression: false
+            },
+            right: {
+              type: 'JsdocTypeName',
+              value: 'string'
+            }
+          }
+        ]
+      }
+    })
+  })
+
+  describe('labeled tuple with two elements', () => {
+    testFixture({
+      input: '[a: string, b: number]',
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeTuple',
+        elements: [
+          {
+            type: 'JsdocTypeKeyValue',
+            key: 'a',
+            optional: false,
+            readonly: false,
+            meta: {
+              quote: undefined,
+              hasLeftSideExpression: false
+            },
+            right: {
+              type: 'JsdocTypeName',
+              value: 'string'
+            }
+          },
+          {
+            type: 'JsdocTypeKeyValue',
+            key: 'b',
+            optional: false,
+            readonly: false,
+            meta: {
+              quote: undefined,
+              hasLeftSideExpression: false
+            },
+            right: {
+              type: 'JsdocTypeName',
+              value: 'number'
+            }
+          }
+        ]
+      }
+    })
+  })
+
+  describe('mixed labeled tuples', () => {
+    testFixture({
+      input: '[a: string, b]',
+      modes: []
+    })
+  })
 })

--- a/test/traverse.spec.ts
+++ b/test/traverse.spec.ts
@@ -1,7 +1,18 @@
-import { expect } from 'chai'
+import { expect, use } from 'chai'
 import { SinonSpy, spy } from 'sinon'
-import { GenericResult, NameResult, TerminalResult, StringValueResult, UnionResult } from '../src'
+import sinonChai from 'sinon-chai'
+import {
+  GenericResult,
+  NameResult,
+  TerminalResult,
+  StringValueResult,
+  UnionResult,
+  FunctionResult,
+  TupleResult, KeyValueResult
+} from '../src'
 import { traverse } from '../src/traverse'
+
+use(sinonChai)
 
 function expectOrder (calls: Array<[SinonSpy, any[]]>): void {
   const callsCount: Map<SinonSpy, number> = new Map<SinonSpy, number>()
@@ -9,11 +20,11 @@ function expectOrder (calls: Array<[SinonSpy, any[]]>): void {
     const [cb, args] = calls[i]
     const count = (callsCount.has(cb) ? callsCount.get(cb) : 0) as number
     const call = cb.getCall(count)
-    expect(call.calledWithExactly(...args), 'called with correct arguments').to.be.equal(true)
+    expect(call, `call ${i} called with correct arguments`).to.have.been.calledWithExactly(...args)
     if (i > 0) {
       const cbBefore = calls[i - 1][0]
       const callBefore = cbBefore.getCall(cbBefore === cb ? count - 1 : (callsCount.get(cbBefore) as number - 1))
-      expect(callBefore.calledBefore(call), 'called in correct order').to.be.equal(true)
+      expect(callBefore, `call ${i} called in correct order`).to.have.been.calledBefore(call as unknown as SinonSpy)
     }
     callsCount.set(cb, count + 1)
   }

--- a/test/traverse.spec.ts
+++ b/test/traverse.spec.ts
@@ -112,4 +112,85 @@ describe('traverse', () => {
       [onLeave, [union, undefined, undefined]]
     ])
   })
+
+  it('should traverse a nested expression with function and tuple', () => {
+    const onEnter = spy()
+    const onLeave = spy()
+
+    const nameA: NameResult = {
+      type: 'JsdocTypeName',
+      value: 'number'
+    }
+
+    const nameB: NameResult = {
+      type: 'JsdocTypeName',
+      value: 'string'
+    }
+
+    const keyValueA: KeyValueResult = {
+      type: 'JsdocTypeKeyValue',
+      key: 'a',
+      right: nameA,
+      optional: false,
+      readonly: false,
+      meta: {
+        quote: undefined,
+        hasLeftSideExpression: false
+      }
+    }
+
+    const keyValueB: KeyValueResult = {
+      type: 'JsdocTypeKeyValue',
+      key: 'b',
+      right: nameB,
+      optional: false,
+      readonly: false,
+      meta: {
+        quote: undefined,
+        hasLeftSideExpression: false
+      }
+    }
+
+    const tuple: TupleResult = {
+      type: 'JsdocTypeTuple',
+      elements: [
+        keyValueA,
+        keyValueB
+      ]
+    }
+
+    const parameter: NameResult = {
+      type: 'JsdocTypeName',
+      value: 'parameter'
+    }
+
+    const functionResult: FunctionResult = {
+      type: 'JsdocTypeFunction',
+      arrow: true,
+      parenthesis: true,
+      parameters: [
+        parameter
+      ],
+      returnType: tuple
+    }
+
+    traverse(functionResult, onEnter, onLeave)
+
+    expectOrder([
+      [onEnter, [functionResult, undefined, undefined]],
+      [onEnter, [parameter, functionResult, 'parameters']],
+      [onLeave, [parameter, functionResult, 'parameters']],
+      [onEnter, [tuple, functionResult, 'returnType']],
+      [onEnter, [keyValueA, tuple, 'elements']],
+      [onEnter, [nameA, keyValueA, 'right']],
+      [onLeave, [nameA, keyValueA, 'right']],
+      [onLeave, [keyValueA, tuple, 'elements']],
+      [onEnter, [keyValueB, tuple, 'elements']],
+      [onEnter, [nameB, keyValueB, 'right']],
+      [onLeave, [nameB, keyValueB, 'right']],
+      [onLeave, [keyValueB, tuple, 'elements']],
+      [onLeave, [tuple, functionResult, 'returnType']],
+      [onLeave, [functionResult, undefined, undefined]]
+    ])
+  })
 })


### PR DESCRIPTION
Adds labeled tuples support. Changes `JsdocTypeKeyValue` result slightly.

Fixes #88 