### PR TITLE
fix: use correct precedence for right side of arrow function

### DIFF
--- a/src/parslets/ArrowFunctionParslet.ts
+++ b/src/parslets/ArrowFunctionParslet.ts
@@ -14,7 +14,7 @@ export const arrowFunctionParslet = composeParslet({
       parameters: getParameters(left).map(assertPlainKeyValueOrNameResult),
       arrow: true,
       parenthesis: true,
-      returnType: parser.parseType(Precedence.ALL)
+      returnType: parser.parseType(Precedence.OBJECT)
     }
   }
 })

--- a/test/fixtures/typescript/arrowFunction.spec.ts
+++ b/test/fixtures/typescript/arrowFunction.spec.ts
@@ -543,6 +543,55 @@ describe('typescript arrow function tests', () => {
       }
     })
   })
+
+  describe('arrow as first object property', () => {
+    testFixture({
+      input: '{x: () => void, y: string}',
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeObject',
+        elements: [
+          {
+            type: 'JsdocTypeKeyValue',
+            key: 'x',
+            right: {
+              type: 'JsdocTypeFunction',
+              parameters: [],
+              returnType: {
+                type: 'JsdocTypeName',
+                value: 'void'
+              },
+              arrow: true,
+              parenthesis: true
+            },
+            optional: false,
+            readonly: false,
+            meta: {
+              quote: undefined,
+              hasLeftSideExpression: false
+            }
+          },
+          {
+            type: 'JsdocTypeKeyValue',
+            key: 'y',
+            right: {
+              type: 'JsdocTypeName',
+              value: 'string'
+            },
+            optional: false,
+            readonly: false,
+            meta: {
+              quote: undefined,
+              hasLeftSideExpression: false
+            }
+          }
+        ],
+        meta: {
+          separator: 'comma'
+        }
+      }
+    })
+  })
 })
 
 // TODO:


### PR DESCRIPTION
Fixes #119 