### PR TITLE
feat: Lexer has a readonly state

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,40 +1,38 @@
 import { EarlyEndOfParseError, NoParsletFoundError } from './errors'
-import { TokenType } from './lexer/Token'
 import { Lexer } from './lexer/Lexer'
 import { Grammar } from './grammars/Grammar'
 import { assertRootResult } from './assertTypes'
 import { Precedence } from './Precedence'
 import { RootResult } from './result/RootResult'
 import { IntermediateResult } from './result/IntermediateResult'
-
-interface ParserOptions {
-  grammar: Grammar
-  lexer?: Lexer
-  parent?: Parser
-}
+import { TokenType } from './lexer/Token'
 
 export class Parser {
   private readonly grammar: Grammar
+  private _lexer: Lexer
+  public readonly parent?: Parser
 
-  private readonly lexer: Lexer
-  private readonly parent?: Parser
-
-  constructor ({ grammar, lexer, parent }: ParserOptions) {
-    this.lexer = lexer ?? new Lexer()
-
-    this.parent = parent
-
+  constructor (grammar: Grammar, textOrLexer: string | Lexer, parent?: Parser) {
     this.grammar = grammar
+    if (typeof textOrLexer === 'string') {
+      this._lexer = Lexer.create(textOrLexer)
+    } else {
+      this._lexer = textOrLexer
+    }
+    this.parent = parent
+  }
+
+  get lexer (): Lexer {
+    return this._lexer
   }
 
   /**
    * Parses a given string and throws an error if the parse ended before the end of the string.
    */
-  parseText (text: string): RootResult {
-    this.lexer.lex(text)
+  parse (): RootResult {
     const result = this.parseType(Precedence.ALL)
-    if (this.lexer.token().type !== 'EOF') {
-      throw new EarlyEndOfParseError(this.lexer.token())
+    if (this.lexer.current.type !== 'EOF') {
+      throw new EarlyEndOfParseError(this.lexer.current)
     }
     return result
   }
@@ -47,9 +45,38 @@ export class Parser {
   }
 
   /**
+   * The main parsing function. First it tries to parse the current state in the prefix step, and then it continues
+   * to parse the state in the infix step.
+   */
+  public parseIntermediateType (precedence: Precedence): IntermediateResult {
+    const result = this.tryParslets(null, precedence)
+
+    if (result === null) {
+      throw new NoParsletFoundError(this.lexer.current)
+    }
+
+    return this.parseInfixIntermediateType(result, precedence)
+  }
+
+  /**
+   * In the infix parsing step the parser continues to parse the current state with all parslets until none returns
+   * a result.
+   */
+  public parseInfixIntermediateType (left: IntermediateResult, precedence: Precedence): IntermediateResult {
+    let result = this.tryParslets(left, precedence)
+
+    while (result !== null) {
+      left = result
+      result = this.tryParslets(left, precedence)
+    }
+
+    return left
+  }
+
+  /**
    * Tries to parse the current state with all parslets in the grammar and returns the first non null result.
    */
-  private tryParslets (precedence: Precedence, left: IntermediateResult | null): IntermediateResult | null {
+  private tryParslets (left: IntermediateResult | null, precedence: Precedence): IntermediateResult | null {
     for (const parslet of this.grammar) {
       const result = parslet(this, precedence, left)
       if (result !== null) {
@@ -60,54 +87,23 @@ export class Parser {
   }
 
   /**
-   * The main parsing function. First it tries to parse the current state in the prefix step, and then it continues
-   * to parse the state in the infix step.
-   */
-  public parseIntermediateType (precedence: Precedence): IntermediateResult {
-    const result = this.tryParslets(precedence, null)
-
-    if (result === null) {
-      throw new NoParsletFoundError(this.lexer.token())
-    }
-
-    return this.parseInfixIntermediateType(result, precedence)
-  }
-
-  /**
-   * In the infix parsing step the parser continues to parse the current state with all parslets until none returns
-   * a result.
-   */
-  public parseInfixIntermediateType (result: IntermediateResult, precedence: Precedence): IntermediateResult {
-    let newResult = this.tryParslets(precedence, result)
-
-    while (newResult !== null) {
-      result = newResult
-      newResult = this.tryParslets(precedence, result)
-    }
-
-    return result
-  }
-
-  /**
    * If the given type equals the current type of the {@link Lexer} advance the lexer. Return true if the lexer was
    * advanced.
    */
-  public consume (types: TokenType|TokenType[]): boolean {
+  public consume (types: TokenType | TokenType[]): boolean {
     if (!Array.isArray(types)) {
       types = [types]
     }
-    if (!types.includes(this.lexer.token().type)) {
+
+    if (types.includes(this.lexer.current.type)) {
+      this._lexer = this.lexer.advance()
+      return true
+    } else {
       return false
     }
-    this.lexer.advance()
-    return true
   }
 
-  getLexer (): Lexer {
-    return this.lexer
-  }
-
-  getParent (): Parser | undefined {
-    return this.parent
+  public acceptLexerState (parser: Parser): void {
+    this._lexer = parser.lexer
   }
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -6,25 +6,20 @@ import { RootResult } from './result/RootResult'
 
 export type ParseMode = 'closure' | 'jsdoc' | 'typescript'
 
-const parsers = {
-  jsdoc: new Parser({
-    grammar: jsdocGrammar
-  }),
-  closure: new Parser({
-    grammar: closureGrammar
-  }),
-  typescript: new Parser({
-    grammar: typescriptGrammar
-  })
-}
-
 /**
  * This function parses the given expression in the given mode and produces a {@link RootResult}.
  * @param expression
  * @param mode
  */
 export function parse (expression: string, mode: ParseMode): RootResult {
-  return parsers[mode].parseText(expression)
+  switch (mode) {
+    case 'closure':
+      return (new Parser(closureGrammar, expression)).parse()
+    case 'jsdoc':
+      return (new Parser(jsdocGrammar, expression)).parse()
+    case 'typescript':
+      return (new Parser(typescriptGrammar, expression)).parse()
+  }
 }
 
 /**
@@ -38,7 +33,7 @@ export function tryParse (expression: string, modes: ParseMode[] = ['typescript'
   let error
   for (const mode of modes) {
     try {
-      return parsers[mode].parseText(expression)
+      return parse(expression, mode)
     } catch (e) {
       error = e
     }

--- a/src/parslets/FunctionParslet.ts
+++ b/src/parslets/FunctionParslet.ts
@@ -38,7 +38,7 @@ export function createFunctionParslet ({ allowNamedParameters, allowNoReturnType
     parsePrefix: parser => {
       parser.consume('function')
 
-      const hasParenthesis = parser.getLexer().token().type === '('
+      const hasParenthesis = parser.lexer.current.type === '('
 
       if (!hasParenthesis) {
         if (!allowWithoutParenthesis) {

--- a/src/parslets/NameParslet.ts
+++ b/src/parslets/NameParslet.ts
@@ -8,7 +8,7 @@ export function createNameParslet ({ allowedAdditionalTokens }: {
     name: 'nameParslet',
     accept: type => type === 'Identifier' || type === 'this' || type === 'new' || allowedAdditionalTokens.includes(type),
     parsePrefix: parser => {
-      const { type, text } = parser.getLexer().token()
+      const { type, text } = parser.lexer.current
       parser.consume(type)
 
       return {

--- a/src/parslets/NamePathParslet.ts
+++ b/src/parslets/NamePathParslet.ts
@@ -15,8 +15,8 @@ export function createNamePathParslet ({ allowJsdocNamePaths, pathGrammar }: {
     if ((left == null) || precedence >= Precedence.NAME_PATH) {
       return null
     }
-    const type = parser.getLexer().token().type
-    const next = parser.getLexer().peek().type
+    const type = parser.lexer.current.type
+    const next = parser.lexer.next.type
 
     const accept = (type === '.' && next !== '<') ||
       (type === '[' && left.type === 'JsdocTypeName') ||
@@ -42,13 +42,11 @@ export function createNamePathParslet ({ allowJsdocNamePaths, pathGrammar }: {
     }
 
     const pathParser = pathGrammar !== null
-      ? new Parser({
-        grammar: pathGrammar,
-        lexer: parser.getLexer()
-      })
+      ? new Parser(pathGrammar, parser.lexer, parser)
       : parser
 
     const parsed = pathParser.parseIntermediateType(Precedence.NAME_PATH)
+    parser.acceptLexerState(pathParser)
     let right: PropertyResult | SpecialNamePath<'event'>
 
     switch (parsed.type) {
@@ -91,7 +89,7 @@ export function createNamePathParslet ({ allowJsdocNamePaths, pathGrammar }: {
     }
 
     if (brackets && !parser.consume(']')) {
-      const token = parser.getLexer().token()
+      const token = parser.lexer.current
       throw new Error(`Unterminated square brackets. Next token is '${token.type}' ` +
         `with text '${token.text}'`)
     }

--- a/src/parslets/NullableParslets.ts
+++ b/src/parslets/NullableParslets.ts
@@ -4,8 +4,8 @@ import { isQuestionMarkUnknownType } from './isQuestionMarkUnkownType'
 import { assertRootResult } from '../assertTypes'
 
 export const nullableParslet: ParsletFunction = (parser, precedence, left) => {
-  const type = parser.getLexer().token().type
-  const next = parser.getLexer().peek().type
+  const type = parser.lexer.current.type
+  const next = parser.lexer.next.type
 
   const accept = ((left == null) && type === '?' && !isQuestionMarkUnknownType(next)) ||
     ((left != null) && type === '?')

--- a/src/parslets/NumberParslet.ts
+++ b/src/parslets/NumberParslet.ts
@@ -4,7 +4,7 @@ export const numberParslet = composeParslet({
   name: 'numberParslet',
   accept: type => type === 'Number',
   parsePrefix: parser => {
-    const value = parseFloat(parser.getLexer().token().text)
+    const value = parseFloat(parser.lexer.current.text)
     parser.consume('Number')
     return {
       type: 'JsdocTypeNumber',

--- a/src/parslets/ObjectParslet.ts
+++ b/src/parslets/ObjectParslet.ts
@@ -25,16 +25,12 @@ export function createObjectParslet ({ objectFieldGrammar, allowKeyTypes }: {
       if (!parser.consume('}')) {
         let separator: 'comma' | 'semicolon' | undefined
 
-        const lexer = parser.getLexer()
-
-        const fieldParser = new Parser({
-          grammar: objectFieldGrammar,
-          lexer: lexer,
-          parent: parser
-        })
+        const fieldParser = new Parser(objectFieldGrammar, parser.lexer, parser)
 
         while (true) {
+          fieldParser.acceptLexerState(parser)
           let field = fieldParser.parseIntermediateType(Precedence.OBJECT)
+          parser.acceptLexerState(fieldParser)
 
           if (field === undefined && allowKeyTypes) {
             field = parser.parseIntermediateType(Precedence.OBJECT)

--- a/src/parslets/Parslet.ts
+++ b/src/parslets/Parslet.ts
@@ -29,11 +29,11 @@ type ComposeInfixParsletOptions = BaseComposeParsletOptions & {
 export type ComposeParsletOptions = ComposePrefixParsletOptions | ComposeInfixParsletOptions | (ComposePrefixParsletOptions & ComposeInfixParsletOptions)
 
 export function composeParslet (options: ComposeParsletOptions): ParsletFunction {
-  const parslet = (parser: Parser, curPrecedence: Precedence, left: IntermediateResult | null): IntermediateResult | null => {
-    const type = parser.getLexer().token().type
-    const next = parser.getLexer().peek().type
+  const parslet: ParsletFunction = (parser, curPrecedence, left) => {
+    const type = parser.lexer.current.type
+    const next = parser.lexer.next.type
 
-    if (left == null) {
+    if (left === null) {
       if ('parsePrefix' in options) {
         if (options.accept(type, next)) {
           return options.parsePrefix(parser)
@@ -46,7 +46,6 @@ export function composeParslet (options: ComposeParsletOptions): ParsletFunction
         }
       }
     }
-
     return null
   }
   if (options.name !== undefined) {

--- a/src/parslets/SpecialTypesParslet.ts
+++ b/src/parslets/SpecialTypesParslet.ts
@@ -30,6 +30,6 @@ export const specialTypesParslet = composeParslet({
       }
     }
 
-    throw new Error('Unacceptable token: ' + parser.getLexer().token().text)
+    throw new Error('Unacceptable token: ' + parser.lexer.current.text)
   }
 })

--- a/src/parslets/StringValueParslet.ts
+++ b/src/parslets/StringValueParslet.ts
@@ -4,7 +4,7 @@ export const stringValueParslet = composeParslet({
   name: 'stringValueParslet',
   accept: type => type === 'StringValue',
   parsePrefix: parser => {
-    const text = parser.getLexer().token().text
+    const text = parser.lexer.current.text
     parser.consume('StringValue')
     return {
       type: 'JsdocTypeStringValue',

--- a/test/lexer.spec.ts
+++ b/test/lexer.spec.ts
@@ -3,16 +3,15 @@ import { Lexer } from '../src/lexer/Lexer'
 import { Token } from '../src/lexer/Token'
 
 function expectTokens (text: string, tokens: Token[]): void {
-  const lexer = new Lexer()
-  lexer.lex(text)
+  let lexer = Lexer.create(text)
 
   let position = 0
 
-  while (lexer.token().type !== 'EOF') {
-    const nextToken = lexer.token()
+  while (lexer.current.type !== 'EOF') {
+    const nextToken = lexer.current
     const nextExpected = tokens[position]
     expect(nextToken).to.deep.equal(nextExpected)
-    lexer.advance()
+    lexer = lexer.advance()
     position++
   }
 


### PR DESCRIPTION
This change was done to be able to introduce some backtracking features, which will be needed for more complicated key parsing of object types.

BREAKING CHANGE: the advance function of the lexer does not change the internal state of the object, but does instead return a new Lexer object. The getters `token()`, `peek()` and `previous()` have been replaced with readonly properties `current`, `next`, `previous`.

BREAKING CHANGE: the API of the Parser class has changed. It can't parse multiple expressions anymore, but needs to be instantiated for each expression. The expression is passed to the constructor. The current lexer can be accessed via the property `lexer`.