### PR TITLE
feat: split KeyValueResult in different types for objects and other uses

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -10,16 +10,16 @@ import { TokenType } from './lexer/Token'
 export class Parser {
   private readonly grammar: Grammar
   private _lexer: Lexer
-  public readonly parent?: Parser
+  public readonly baseParser?: Parser
 
-  constructor (grammar: Grammar, textOrLexer: string | Lexer, parent?: Parser) {
+  constructor (grammar: Grammar, textOrLexer: string | Lexer, baseParser?: Parser) {
     this.grammar = grammar
     if (typeof textOrLexer === 'string') {
       this._lexer = Lexer.create(textOrLexer)
     } else {
       this._lexer = textOrLexer
     }
-    this.parent = parent
+    this.baseParser = baseParser
   }
 
   get lexer (): Lexer {

--- a/src/assertTypes.ts
+++ b/src/assertTypes.ts
@@ -10,7 +10,11 @@ export function assertRootResult (result?: IntermediateResult): RootResult {
   if (result === undefined) {
     throw new Error('Unexpected undefined')
   }
-  if (result.type === 'JsdocTypeKeyValue' || result.type === 'JsdocTypeParameterList' || result.type === 'JsdocTypeProperty' || result.type === 'JsdocTypeReadonlyProperty') {
+  if (
+    result.type === 'JsdocTypeKeyValue' || result.type === 'JsdocTypeParameterList' ||
+    result.type === 'JsdocTypeProperty' || result.type === 'JsdocTypeReadonlyProperty' ||
+    result.type === 'JsdocTypeObjectField' || result.type === 'JsdocTypeJsdocObjectField'
+  ) {
     throw new UnexpectedTypeError(result)
   }
   return result
@@ -31,12 +35,8 @@ export function assertPlainKeyValueOrNameResult (result: IntermediateResult): Ke
 }
 
 export function assertPlainKeyValueResult (result: IntermediateResult): KeyValueResult {
-  if (!isPlainKeyValue(result)) {
-    if (result.type === 'JsdocTypeKeyValue') {
-      throw new UnexpectedTypeError(result, 'Expecting no left side expression.')
-    } else {
-      throw new UnexpectedTypeError(result)
-    }
+  if (result.type !== 'JsdocTypeKeyValue') {
+    throw new UnexpectedTypeError(result)
   }
   return result
 }
@@ -52,8 +52,4 @@ export function assertNumberOrVariadicNameResult (result: IntermediateResult): N
     throw new UnexpectedTypeError(result)
   }
   return result
-}
-
-export function isPlainKeyValue (result: IntermediateResult): result is KeyValueResult {
-  return result.type === 'JsdocTypeKeyValue' && !result.meta.hasLeftSideExpression
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,5 @@
-import { Token } from './lexer/Token'
-import { IntermediateResult } from './result/IntermediateResult'
+import { type Token } from './lexer/Token'
+import { type IntermediateResult } from './result/IntermediateResult'
 
 function tokenToString (token: Token): string {
   if (token.text !== undefined && token.text !== '') {
@@ -42,8 +42,8 @@ export class EarlyEndOfParseError extends Error {
 }
 
 export class UnexpectedTypeError extends Error {
-  constructor (result?: IntermediateResult, message?: string) {
-    let error = `Unexpected type: '${result?.type ?? 'undefined'}'.`
+  constructor (result: IntermediateResult, message?: string) {
+    let error = `Unexpected type: '${result.type}'.`
     if (message !== undefined) {
       error += ` Message: ${message}`
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -42,8 +42,8 @@ export class EarlyEndOfParseError extends Error {
 }
 
 export class UnexpectedTypeError extends Error {
-  constructor (result: IntermediateResult, message?: string) {
-    let error = `Unexpected type: '${result.type}'.`
+  constructor (result?: IntermediateResult, message?: string) {
+    let error = `Unexpected type: '${result?.type ?? 'undefined'}'.`
     if (message !== undefined) {
       error += ` Message: ${message}`
     }

--- a/src/grammars/closureGrammar.ts
+++ b/src/grammars/closureGrammar.ts
@@ -14,6 +14,7 @@ import { createVariadicParslet } from '../parslets/VariadicParslet'
 import { createSpecialNamePathParslet } from '../parslets/SpecialNamePathParslet'
 import { createNamePathParslet } from '../parslets/NamePathParslet'
 import { symbolParslet } from '../parslets/SymbolParslet'
+import { createObjectFieldParslet } from '../parslets/ObjectFieldParslet'
 
 const objectFieldGrammar: Grammar = [
   createNameParslet({
@@ -23,7 +24,7 @@ const objectFieldGrammar: Grammar = [
   optionalParslet,
   stringValueParslet,
   numberParslet,
-  createKeyValueParslet({
+  createObjectFieldParslet({
     allowKeyTypes: false,
     allowOptional: false,
     allowReadonly: false,
@@ -64,9 +65,7 @@ export const closureGrammar = [
     pathGrammar
   }),
   createKeyValueParslet({
-    allowKeyTypes: false,
     allowOptional: false,
-    allowReadonly: false,
     allowVariadic: false
   }),
   symbolParslet

--- a/src/grammars/closureGrammar.ts
+++ b/src/grammars/closureGrammar.ts
@@ -2,7 +2,7 @@ import { baseGrammar } from './baseGrammar'
 import { pathGrammar } from './pathGrammar'
 import { createNameParslet } from '../parslets/NameParslet'
 import { nullableParslet } from '../parslets/NullableParslets'
-import { Grammar } from './Grammar'
+import { type Grammar } from './Grammar'
 import { optionalParslet } from '../parslets/OptionalParslet'
 import { stringValueParslet } from '../parslets/StringValueParslet'
 import { numberParslet } from '../parslets/NumberParslet'
@@ -27,8 +27,7 @@ const objectFieldGrammar: Grammar = [
   createObjectFieldParslet({
     allowKeyTypes: false,
     allowOptional: false,
-    allowReadonly: false,
-    allowVariadic: false
+    allowReadonly: false
   })
 ]
 

--- a/src/grammars/jsdocGrammar.ts
+++ b/src/grammars/jsdocGrammar.ts
@@ -1,5 +1,5 @@
 import { baseGrammar } from './baseGrammar'
-import { Grammar } from './Grammar'
+import { type Grammar } from './Grammar'
 import { pathGrammar } from './pathGrammar'
 import { createFunctionParslet } from '../parslets/FunctionParslet'
 import { stringValueParslet } from '../parslets/StringValueParslet'
@@ -53,8 +53,7 @@ export const jsdocGrammar: Grammar = [
       createObjectFieldParslet({
         allowKeyTypes: true,
         allowOptional: false,
-        allowReadonly: false,
-        allowVariadic: false
+        allowReadonly: false
       }),
       ...jsdocBaseGrammar
     ],

--- a/src/grammars/jsdocGrammar.ts
+++ b/src/grammars/jsdocGrammar.ts
@@ -9,8 +9,9 @@ import { createNameParslet } from '../parslets/NameParslet'
 import { symbolParslet } from '../parslets/SymbolParslet'
 import { arrayBracketsParslet } from '../parslets/ArrayBracketsParslet'
 import { createNamePathParslet } from '../parslets/NamePathParslet'
-import { createKeyValueParslet } from '../parslets/KeyValueParslet'
 import { createObjectParslet } from '../parslets/ObjectParslet'
+import { createObjectFieldParslet } from '../parslets/ObjectFieldParslet'
+import { createKeyValueParslet } from '../parslets/KeyValueParslet'
 
 const jsdocBaseGrammar = [
   ...baseGrammar,
@@ -37,12 +38,6 @@ const jsdocBaseGrammar = [
   createNamePathParslet({
     allowJsdocNamePaths: true,
     pathGrammar
-  }),
-  createKeyValueParslet({
-    allowKeyTypes: true,
-    allowOptional: false,
-    allowReadonly: false,
-    allowVariadic: false
   })
 ]
 
@@ -55,8 +50,18 @@ export const jsdocGrammar: Grammar = [
       createNameParslet({
         allowedAdditionalTokens: ['module']
       }),
+      createObjectFieldParslet({
+        allowKeyTypes: true,
+        allowOptional: false,
+        allowReadonly: false,
+        allowVariadic: false
+      }),
       ...jsdocBaseGrammar
     ],
     allowKeyTypes: true
+  }),
+  createKeyValueParslet({
+    allowOptional: true,
+    allowVariadic: true
   })
 ]

--- a/src/grammars/typescriptGrammar.ts
+++ b/src/grammars/typescriptGrammar.ts
@@ -1,5 +1,5 @@
 import { baseGrammar } from './baseGrammar'
-import { Grammar } from './Grammar'
+import { type Grammar } from './Grammar'
 import { pathGrammar } from './pathGrammar'
 import { createNameParslet } from '../parslets/NameParslet'
 import { nullableParslet } from '../parslets/NullableParslets'
@@ -35,8 +35,7 @@ const objectFieldGrammar: Grammar = [
   createObjectFieldParslet({
     allowKeyTypes: false,
     allowOptional: true,
-    allowReadonly: true,
-    allowVariadic: false
+    allowReadonly: true
   })
 ]
 

--- a/src/grammars/typescriptGrammar.ts
+++ b/src/grammars/typescriptGrammar.ts
@@ -6,7 +6,6 @@ import { nullableParslet } from '../parslets/NullableParslets'
 import { optionalParslet } from '../parslets/OptionalParslet'
 import { stringValueParslet } from '../parslets/StringValueParslet'
 import { numberParslet } from '../parslets/NumberParslet'
-import { createKeyValueParslet } from '../parslets/KeyValueParslet'
 import { createFunctionParslet } from '../parslets/FunctionParslet'
 import { createObjectParslet } from '../parslets/ObjectParslet'
 import { createTupleParslet } from '../parslets/TupleParslet'
@@ -21,6 +20,8 @@ import { arrowFunctionParslet } from '../parslets/ArrowFunctionParslet'
 import { createNamePathParslet } from '../parslets/NamePathParslet'
 import { intersectionParslet } from '../parslets/IntersectionParslet'
 import { predicateParslet } from '../parslets/predicateParslet'
+import { createObjectFieldParslet } from '../parslets/ObjectFieldParslet'
+import { createKeyValueParslet } from '../parslets/KeyValueParslet'
 
 const objectFieldGrammar: Grammar = [
   readonlyPropertyParslet,
@@ -31,7 +32,7 @@ const objectFieldGrammar: Grammar = [
   optionalParslet,
   stringValueParslet,
   numberParslet,
-  createKeyValueParslet({
+  createObjectFieldParslet({
     allowKeyTypes: false,
     allowOptional: true,
     allowReadonly: true,
@@ -75,12 +76,10 @@ export const typescriptGrammar: Grammar = [
     allowJsdocNamePaths: false,
     pathGrammar
   }),
-  createKeyValueParslet({
-    allowKeyTypes: false,
-    allowOptional: true,
-    allowReadonly: true,
-    allowVariadic: true
-  }),
   intersectionParslet,
-  predicateParslet
+  predicateParslet,
+  createKeyValueParslet({
+    allowVariadic: true,
+    allowOptional: true
+  })
 ]

--- a/src/parslets/FunctionParslet.ts
+++ b/src/parslets/FunctionParslet.ts
@@ -72,7 +72,7 @@ export function createFunctionParslet ({ allowNamedParameters, allowNoReturnType
       } else {
         result.parameters = getParameters(value)
         for (const p of result.parameters) {
-          if (p.type === 'JsdocTypeKeyValue' && (!allowNamedParameters.includes(p.key) || p.meta.quote !== undefined)) {
+          if (p.type === 'JsdocTypeKeyValue' && (!allowNamedParameters.includes(p.key))) {
             throw new Error(`only allowed named parameters are ${allowNamedParameters.join(', ')} but got ${p.type}`)
           }
         }

--- a/src/parslets/KeyValueParslet.ts
+++ b/src/parslets/KeyValueParslet.ts
@@ -1,12 +1,9 @@
 import { composeParslet, type ParsletFunction } from './Parslet'
 import { Precedence } from '../Precedence'
-import { assertRootResult } from '../assertTypes'
 import { UnexpectedTypeError } from '../errors'
 
-export function createKeyValueParslet ({ allowKeyTypes, allowReadonly, allowOptional, allowVariadic }: {
-  allowKeyTypes: boolean
+export function createKeyValueParslet ({ allowOptional, allowVariadic }: {
   allowOptional: boolean
-  allowReadonly: boolean
   allowVariadic: boolean
 }): ParsletFunction {
   return composeParslet({
@@ -15,16 +12,10 @@ export function createKeyValueParslet ({ allowKeyTypes, allowReadonly, allowOpti
     accept: type => type === ':',
     parseInfix: (parser, left) => {
       let optional = false
-      let readonlyProperty = false
       let variadic = false
 
       if (allowOptional && left.type === 'JsdocTypeNullable') {
         optional = true
-        left = left.element
-      }
-
-      if (allowReadonly && left.type === 'JsdocTypeReadonlyProperty') {
-        readonlyProperty = true
         left = left.element
       }
 
@@ -33,51 +24,20 @@ export function createKeyValueParslet ({ allowKeyTypes, allowReadonly, allowOpti
         left = left.element
       }
 
-      // object parslet uses a special grammar and for the value we want to switch back to the parent
-      const parentParser = parser.parent ?? parser
-      parentParser.acceptLexerState(parser)
+      if (left.type !== 'JsdocTypeName') {
+        throw new UnexpectedTypeError(left)
+      }
 
-      if (left.type === 'JsdocTypeNumber' || left.type === 'JsdocTypeName' || left.type === 'JsdocTypeStringValue') {
-        parentParser.consume(':')
+      parser.consume(':')
 
-        let quote
-        if (left.type === 'JsdocTypeStringValue') {
-          quote = left.meta.quote
-        }
+      const right = parser.parseType(Precedence.KEY_VALUE)
 
-        const right = parentParser.parseType(Precedence.KEY_VALUE)
-        parser.acceptLexerState(parentParser)
-
-        return {
-          type: 'JsdocTypeKeyValue',
-          key: left.value.toString(),
-          right,
-          optional,
-          readonly: readonlyProperty,
-          variadic,
-          meta: {
-            quote,
-            hasLeftSideExpression: false
-          }
-        }
-      } else {
-        if (!allowKeyTypes) {
-          throw new UnexpectedTypeError(left)
-        }
-
-        parentParser.consume(':')
-
-        const right = parentParser.parseType(Precedence.KEY_VALUE)
-        parser.acceptLexerState(parentParser)
-
-        return {
-          type: 'JsdocTypeKeyValue',
-          left: assertRootResult(left),
-          right,
-          meta: {
-            hasLeftSideExpression: true
-          }
-        }
+      return {
+        type: 'JsdocTypeKeyValue',
+        key: left.value,
+        right,
+        optional,
+        variadic
       }
     }
   })

--- a/src/parslets/ObjectFieldParslet.ts
+++ b/src/parslets/ObjectFieldParslet.ts
@@ -1,13 +1,12 @@
-import { composeParslet, ParsletFunction } from './Parslet'
+import { composeParslet, type ParsletFunction } from './Parslet'
 import { Precedence } from '../Precedence'
 import { UnexpectedTypeError } from '../errors'
 import { assertRootResult } from '../assertTypes'
 
-export function createObjectFieldParslet ({ allowKeyTypes, allowReadonly, allowOptional, allowVariadic }: {
+export function createObjectFieldParslet ({ allowKeyTypes, allowReadonly, allowOptional }: {
   allowKeyTypes: boolean
   allowOptional: boolean
   allowReadonly: boolean
-  allowVariadic: boolean
 }): ParsletFunction {
   return composeParslet({
     name: 'objectFieldParslet',
@@ -16,7 +15,6 @@ export function createObjectFieldParslet ({ allowKeyTypes, allowReadonly, allowO
     parseInfix: (parser, left) => {
       let optional = false
       let readonlyProperty = false
-      let variadic = false
 
       if (allowOptional && left.type === 'JsdocTypeNullable') {
         optional = true
@@ -25,11 +23,6 @@ export function createObjectFieldParslet ({ allowKeyTypes, allowReadonly, allowO
 
       if (allowReadonly && left.type === 'JsdocTypeReadonlyProperty') {
         readonlyProperty = true
-        left = left.element
-      }
-
-      if (allowVariadic && left.type === 'JsdocTypeVariadic' && left.element !== undefined) {
-        variadic = true
         left = left.element
       }
 
@@ -54,7 +47,6 @@ export function createObjectFieldParslet ({ allowKeyTypes, allowReadonly, allowO
           right,
           optional,
           readonly: readonlyProperty,
-          variadic,
           meta: {
             quote
           }
@@ -72,7 +64,7 @@ export function createObjectFieldParslet ({ allowKeyTypes, allowReadonly, allowO
         return {
           type: 'JsdocTypeJsdocObjectField',
           left: assertRootResult(left),
-          right: right
+          right
         }
       }
     }

--- a/src/parslets/ObjectFieldParslet.ts
+++ b/src/parslets/ObjectFieldParslet.ts
@@ -1,0 +1,80 @@
+import { composeParslet, ParsletFunction } from './Parslet'
+import { Precedence } from '../Precedence'
+import { UnexpectedTypeError } from '../errors'
+import { assertRootResult } from '../assertTypes'
+
+export function createObjectFieldParslet ({ allowKeyTypes, allowReadonly, allowOptional, allowVariadic }: {
+  allowKeyTypes: boolean
+  allowOptional: boolean
+  allowReadonly: boolean
+  allowVariadic: boolean
+}): ParsletFunction {
+  return composeParslet({
+    name: 'objectFieldParslet',
+    precedence: Precedence.KEY_VALUE,
+    accept: type => type === ':',
+    parseInfix: (parser, left) => {
+      let optional = false
+      let readonlyProperty = false
+      let variadic = false
+
+      if (allowOptional && left.type === 'JsdocTypeNullable') {
+        optional = true
+        left = left.element
+      }
+
+      if (allowReadonly && left.type === 'JsdocTypeReadonlyProperty') {
+        readonlyProperty = true
+        left = left.element
+      }
+
+      if (allowVariadic && left.type === 'JsdocTypeVariadic' && left.element !== undefined) {
+        variadic = true
+        left = left.element
+      }
+
+      // object parslet uses a special grammar and for the value we want to switch back to the parent
+      const parentParser = parser.baseParser ?? parser
+      parentParser.acceptLexerState(parser)
+
+      if (left.type === 'JsdocTypeNumber' || left.type === 'JsdocTypeName' || left.type === 'JsdocTypeStringValue') {
+        parentParser.consume(':')
+
+        let quote
+        if (left.type === 'JsdocTypeStringValue') {
+          quote = left.meta.quote
+        }
+
+        const right = parentParser.parseType(Precedence.KEY_VALUE)
+        parser.acceptLexerState(parentParser)
+
+        return {
+          type: 'JsdocTypeObjectField',
+          key: left.value.toString(),
+          right,
+          optional,
+          readonly: readonlyProperty,
+          variadic,
+          meta: {
+            quote
+          }
+        }
+      } else {
+        if (!allowKeyTypes) {
+          throw new UnexpectedTypeError(left)
+        }
+
+        parentParser.consume(':')
+
+        const right = parentParser.parseType(Precedence.KEY_VALUE)
+        parser.acceptLexerState(parentParser)
+
+        return {
+          type: 'JsdocTypeJsdocObjectField',
+          left: assertRootResult(left),
+          right: right
+        }
+      }
+    }
+  })
+}

--- a/src/parslets/ObjectParslet.ts
+++ b/src/parslets/ObjectParslet.ts
@@ -49,18 +49,17 @@ export function createObjectParslet ({ objectFieldGrammar, allowKeyTypes }: {
             }
 
             result.elements.push({
-              type: 'JsdocTypeKeyValue',
+              type: 'JsdocTypeObjectField',
               key: field.value.toString(),
               right: undefined,
               optional,
               readonly: false,
               variadic: false,
               meta: {
-                quote,
-                hasLeftSideExpression: false
+                quote
               }
             })
-          } else if (field.type === 'JsdocTypeKeyValue') {
+          } else if (field.type === 'JsdocTypeObjectField' || field.type === 'JsdocTypeJsdocObjectField') {
             result.elements.push(field)
           } else {
             throw new UnexpectedTypeError(field)

--- a/src/parslets/ObjectParslet.ts
+++ b/src/parslets/ObjectParslet.ts
@@ -54,7 +54,6 @@ export function createObjectParslet ({ objectFieldGrammar, allowKeyTypes }: {
               right: undefined,
               optional,
               readonly: false,
-              variadic: false,
               meta: {
                 quote
               }

--- a/src/parslets/ParenthesisParslet.ts
+++ b/src/parslets/ParenthesisParslet.ts
@@ -1,6 +1,6 @@
 import { composeParslet } from './Parslet'
 import { Precedence } from '../Precedence'
-import { assertRootResult, isPlainKeyValue } from '../assertTypes'
+import { assertRootResult } from '../assertTypes'
 
 export const parenthesisParslet = composeParslet({
   name: 'parenthesisParslet',
@@ -19,7 +19,7 @@ export const parenthesisParslet = composeParslet({
     }
     if (result.type === 'JsdocTypeParameterList') {
       return result
-    } else if (result.type === 'JsdocTypeKeyValue' && isPlainKeyValue(result)) {
+    } else if (result.type === 'JsdocTypeKeyValue') {
       return {
         type: 'JsdocTypeParameterList',
         elements: [result]

--- a/src/result/NonRootResult.ts
+++ b/src/result/NonRootResult.ts
@@ -1,13 +1,43 @@
-import { QuoteStyle, RootResult } from './RootResult'
+import {
+  QuoteStyle,
+  RootResult
+} from './RootResult'
 
 /**
  * A parse sub result that might not be a valid type expression on its own.
  */
 export type NonRootResult =
   RootResult
-  | KeyValueResult
-  | JsdocObjectKeyValueResult
   | PropertyResult
+  | ObjectFieldResult
+  | JsdocObjectFieldResult
+  | KeyValueResult
+
+export interface ObjectFieldResult {
+  type: 'JsdocTypeObjectField'
+  key: string
+  right: RootResult | undefined
+  optional: boolean
+  readonly: boolean
+  variadic: boolean
+  meta: {
+    quote: QuoteStyle | undefined
+  }
+}
+
+export interface JsdocObjectFieldResult {
+  type: 'JsdocTypeJsdocObjectField'
+  left: RootResult
+  right: RootResult
+}
+
+export interface PropertyResult {
+  type: 'JsdocTypeProperty'
+  value: string
+  meta: {
+    quote: QuoteStyle | undefined
+  }
+}
 
 /**
  * A key value pair represented by a `:`. Can occur as a named parameter of a {@link FunctionResult} or as an entry for
@@ -19,32 +49,5 @@ export interface KeyValueResult {
   key: string
   right: RootResult | undefined
   optional: boolean
-  readonly: boolean
   variadic: boolean
-  meta: {
-    quote: QuoteStyle | undefined
-    hasLeftSideExpression: false
-  }
-}
-
-/**
- * A key value pair represented by a `:`. This particular variant of the `KEY_VALUE` type will only occur in `'jsdoc'`
- * parsing mode and can only occur in {@link ObjectResult}s. It can be differentiated from {@link KeyValueResult} by
- * the `left` property that will never appear on the latter.
- */
-export interface JsdocObjectKeyValueResult {
-  type: 'JsdocTypeKeyValue'
-  left: RootResult
-  right: RootResult
-  meta: {
-    hasLeftSideExpression: true
-  }
-}
-
-export interface PropertyResult {
-  type: 'JsdocTypeProperty'
-  value: string
-  meta: {
-    quote: QuoteStyle | undefined
-  }
 }

--- a/src/result/NonRootResult.ts
+++ b/src/result/NonRootResult.ts
@@ -1,6 +1,6 @@
 import {
-  QuoteStyle,
-  RootResult
+  type QuoteStyle,
+  type RootResult
 } from './RootResult'
 
 /**
@@ -19,7 +19,6 @@ export interface ObjectFieldResult {
   right: RootResult | undefined
   optional: boolean
   readonly: boolean
-  variadic: boolean
   meta: {
     quote: QuoteStyle | undefined
   }
@@ -41,8 +40,7 @@ export interface PropertyResult {
 
 /**
  * A key value pair represented by a `:`. Can occur as a named parameter of a {@link FunctionResult} or as an entry for
- * an {@link ObjectResult}. Is a {@link NonRootResult}. {@link JsdocObjectKeyValueResult} uses the same type name
- * and will not have a `value` property.
+ * an {@link TupleResult}. Is a {@link NonRootResult}.
  */
 export interface KeyValueResult {
   type: 'JsdocTypeKeyValue'

--- a/src/result/RootResult.ts
+++ b/src/result/RootResult.ts
@@ -1,4 +1,9 @@
-import { type JsdocObjectKeyValueResult, type KeyValueResult, type PropertyResult } from './NonRootResult'
+import {
+  type JsdocObjectFieldResult,
+  type KeyValueResult,
+  type ObjectFieldResult,
+  type PropertyResult
+} from './NonRootResult'
 
 /**
  * A parse result that corresponds to a valid type expression.
@@ -66,8 +71,8 @@ export interface NotNullableResult<T extends RootResult> {
 }
 
 /**
- * A rest or spreaded parameter. It can either occur in `@param` tags or as last parameter of a function,
- * or it is a spreaded tuple or object type and can occur inside these. For any mode that is not `jsdoc` this can
+ * A rest or spread parameter. It can either occur in `@param` tags or as last parameter of a function,
+ * or it is a spread tuple or object type and can occur inside these. For any mode that is not `jsdoc` this can
  * only occur in position `'suffix'`.
  */
 export interface VariadicResult<T extends RootResult> {
@@ -98,7 +103,8 @@ export interface UnionResult {
 /**
  * A generic type. The property `left` is the generic type that has `elements` as type values for its type parameters.
  * Array types that are written as `Type[]` always have the name `Array` as the `left` type and `elements` will contain
- * only one element (in this case the name `Type`). To differentiate `Type[]` and `Array<Type>` there is the meta property
+ * only one element (in this case the name `Type`). To differentiate `Type[]` and `Array<Type>` there is the meta
+ * property
  * `brackets`.
  */
 export interface GenericResult {
@@ -137,7 +143,7 @@ export interface UndefinedResult {
 }
 
 /**
- * The any type, represented by `*` (`any` is parsed as a name).
+ * The `any` type, represented by `*` (`any` is parsed as a name).
  */
 export interface AnyResult {
   type: 'JsdocTypeAny'
@@ -166,13 +172,13 @@ export interface FunctionResult {
 }
 
 /**
- * An object type. Contains entries which can be {@link KeyValueResult}s or {@link NameResult}s. In most grammars the keys
- * need to be {@link NameResult}s. In some grammars it possible that an entry is only a {@link RootResult} or a
- * {@link NumberResult} without a key. The seperator is `'comma'` by default.
+ * An object type. Contains entries which can be {@link KeyValueResult}s or {@link NameResult}s. In most grammars the
+ * keys need to be {@link NameResult}s. In some grammars it possible that an entry is only a {@link RootResult} or a
+ * {@link NumberResult} without a key. The separator is `'comma'` by default.
  */
 export interface ObjectResult {
   type: 'JsdocTypeObject'
-  elements: Array<KeyValueResult | JsdocObjectKeyValueResult>
+  elements: Array<ObjectFieldResult | JsdocObjectFieldResult>
   meta: {
     separator: 'comma' | 'semicolon' | 'linebreak' | undefined
   }
@@ -181,7 +187,7 @@ export interface ObjectResult {
 export type SpecialNamePathType = 'module' | 'event' | 'external'
 
 /**
- * A module type. Often this is a `left` type of a {@link NamePathResult}.
+ * A module type. Often this is a `left` type of {@link NamePathResult}.
  */
 export interface SpecialNamePath<Type extends SpecialNamePathType = SpecialNamePathType> {
   type: 'JsdocTypeSpecialNamePath'
@@ -270,7 +276,7 @@ export interface NumberResult {
 }
 
 /**
- * A typescript prediciate. Is used in return annotations like this: `@return {x is string}`.
+ * A typescript predicate. Is used in return annotations like this: `@return {x is string}`.
  */
 export interface PredicateResult {
   type: 'JsdocTypePredicate'

--- a/src/transforms/identityTransformRules.ts
+++ b/src/transforms/identityTransformRules.ts
@@ -1,8 +1,9 @@
 import { type TransformRules } from './transform'
 import {
-  type JsdocObjectKeyValueResult,
+  type JsdocObjectFieldResult,
   type KeyValueResult,
-  type NonRootResult
+  type NonRootResult,
+  type ObjectFieldResult
 } from '../result/NonRootResult'
 import {
   type FunctionResult,
@@ -13,7 +14,6 @@ import {
   type VariadicResult,
   type NumberResult
 } from '../result/RootResult'
-import { isPlainKeyValue } from '../assertTypes'
 
 export function identityTransformRules (): TransformRules<NonRootResult> {
   return {
@@ -72,7 +72,7 @@ export function identityTransformRules (): TransformRules<NonRootResult> {
       meta: {
         separator: 'comma'
       },
-      elements: result.elements.map(transform) as Array<KeyValueResult | JsdocObjectKeyValueResult>
+      elements: result.elements.map(transform) as Array<ObjectFieldResult | JsdocObjectFieldResult>
     }),
 
     JsdocTypeNumber: result => result,
@@ -89,24 +89,29 @@ export function identityTransformRules (): TransformRules<NonRootResult> {
 
     JsdocTypeSpecialNamePath: result => result,
 
+    JsdocTypeObjectField: (result, transform) => ({
+      type: 'JsdocTypeObjectField',
+      key: result.key,
+      right: result.right === undefined ? undefined : transform(result.right) as RootResult,
+      optional: result.optional,
+      readonly: result.readonly,
+      variadic: result.variadic,
+      meta: result.meta
+    }),
+
+    JsdocTypeJsdocObjectField: (result, transform) => ({
+      type: 'JsdocTypeJsdocObjectField',
+      left: transform(result.left) as RootResult,
+      right: transform(result.right) as RootResult
+    }),
+
     JsdocTypeKeyValue: (result, transform) => {
-      if (isPlainKeyValue(result)) {
-        return {
-          type: 'JsdocTypeKeyValue',
-          key: result.key,
-          right: result.right === undefined ? undefined : transform(result.right) as RootResult,
-          optional: result.optional,
-          readonly: result.readonly,
-          variadic: result.variadic,
-          meta: result.meta
-        }
-      } else {
-        return {
-          type: 'JsdocTypeKeyValue',
-          left: transform(result.left) as RootResult,
-          right: transform(result.right) as RootResult,
-          meta: result.meta
-        }
+      return {
+        type: 'JsdocTypeKeyValue',
+        key: result.key,
+        right: result.right === undefined ? undefined : transform(result.right) as RootResult,
+        optional: result.optional,
+        variadic: result.variadic
       }
     },
 

--- a/src/transforms/identityTransformRules.ts
+++ b/src/transforms/identityTransformRules.ts
@@ -95,7 +95,6 @@ export function identityTransformRules (): TransformRules<NonRootResult> {
       right: result.right === undefined ? undefined : transform(result.right) as RootResult,
       optional: result.optional,
       readonly: result.readonly,
-      variadic: result.variadic,
       meta: result.meta
     }),
 

--- a/src/transforms/stringify.ts
+++ b/src/transforms/stringify.ts
@@ -1,6 +1,6 @@
-import { transform, TransformRules } from './transform'
-import { NonRootResult } from '../result/NonRootResult'
-import { RootResult } from '../result/RootResult'
+import { transform, type TransformRules } from './transform'
+import { type NonRootResult } from '../result/NonRootResult'
+import { type RootResult } from '../result/RootResult'
 
 function applyPosition (position: 'prefix' | 'suffix', target: string, value: string): string {
   return position === 'prefix' ? value + target : target + value
@@ -97,9 +97,6 @@ export function stringifyRules (): TransformRules<string> {
       text += quote(result.key, result.meta.quote)
       if (result.optional) {
         text += '?'
-      }
-      if (result.variadic) {
-        text = '...' + text
       }
 
       if (result.right === undefined) {

--- a/src/transforms/stringify.ts
+++ b/src/transforms/stringify.ts
@@ -1,7 +1,6 @@
 import { transform, TransformRules } from './transform'
 import { NonRootResult } from '../result/NonRootResult'
 import { RootResult } from '../result/RootResult'
-import { isPlainKeyValue } from '../assertTypes'
 
 function applyPosition (position: 'prefix' | 'suffix', target: string, value: string): string {
   return position === 'prefix' ? value + target : target + value
@@ -90,27 +89,43 @@ export function stringifyRules (): TransformRules<string> {
 
     JsdocTypeImport: (result, transform) => `import(${transform(result.element)})`,
 
-    JsdocTypeKeyValue: (result, transform) => {
-      if (isPlainKeyValue(result)) {
-        let text = ''
-        if (result.readonly) {
-          text += 'readonly '
-        }
-        text += quote(result.key, result.meta.quote)
-        if (result.optional) {
-          text += '?'
-        }
-        if (result.variadic) {
-          text = '...' + text
-        }
+    JsdocTypeObjectField: (result, transform) => {
+      let text = ''
+      if (result.readonly) {
+        text += 'readonly '
+      }
+      text += quote(result.key, result.meta.quote)
+      if (result.optional) {
+        text += '?'
+      }
+      if (result.variadic) {
+        text = '...' + text
+      }
 
-        if (result.right === undefined) {
-          return text
-        } else {
-          return text + `: ${transform(result.right)}`
-        }
+      if (result.right === undefined) {
+        return text
       } else {
-        return `${transform(result.left)}: ${transform(result.right)}`
+        return text + `: ${transform(result.right)}`
+      }
+    },
+
+    JsdocTypeJsdocObjectField: (result, transform) => {
+      return `${transform(result.left)}: ${transform(result.right)}`
+    },
+
+    JsdocTypeKeyValue: (result, transform) => {
+      let text = result.key
+      if (result.optional) {
+        text += '?'
+      }
+      if (result.variadic) {
+        text = '...' + text
+      }
+
+      if (result.right === undefined) {
+        return text
+      } else {
+        return text + `: ${transform(result.right)}`
       }
     },
 

--- a/src/transforms/transform.ts
+++ b/src/transforms/transform.ts
@@ -34,7 +34,7 @@ export function extractSpecialParams (source: FunctionResult): SpecialFunctionPa
   }
 
   for (const param of source.parameters) {
-    if (param.type === 'JsdocTypeKeyValue' && param.meta.quote === undefined) {
+    if (param.type === 'JsdocTypeKeyValue') {
       if (param.key === 'this') {
         result.this = param.right
       } else if (param.key === 'new') {

--- a/src/visitorKeys.ts
+++ b/src/visitorKeys.ts
@@ -19,6 +19,8 @@ export const visitorKeys: VisitorKeys = {
   JsdocTypeNullable: ['element'],
   JsdocTypeNumber: [],
   JsdocTypeObject: ['elements'],
+  JsdocTypeObjectField: ['right'],
+  JsdocTypeJsdocObjectField: ['left', 'right'],
   JsdocTypeOptional: ['element'],
   JsdocTypeParenthesis: ['element'],
   JsdocTypeSpecialNamePath: [],

--- a/test/ObjectParslet.api.spec.ts
+++ b/test/ObjectParslet.api.spec.ts
@@ -45,19 +45,18 @@ describe('`ObjectParslet`', () => {
 
     const rootResult = parser.parse()
 
-    expect(rootResult).to.deep.equal({
+    const expected: RootResult = {
       elements: [
         {
           key: 'abc',
           meta: {
-            hasLeftSideExpression: false,
             quote: undefined
           },
           optional: false,
-          readonly: false,
           variadic: false,
+          readonly: false,
           right: undefined,
-          type: 'JsdocTypeKeyValue'
+          type: 'JsdocTypeObjectField'
         }
       ],
       meta: {
@@ -65,6 +64,7 @@ describe('`ObjectParslet`', () => {
       },
       type: 'JsdocTypeObject'
     }
-    )
+
+    expect(rootResult).to.deep.equal(expected)
   })
 })

--- a/test/ObjectParslet.api.spec.ts
+++ b/test/ObjectParslet.api.spec.ts
@@ -1,12 +1,12 @@
 import { expect } from 'chai'
-import { stub, SinonStub } from 'sinon'
+import { stub, type SinonStub } from 'sinon'
 
 import { jsdocGrammar } from '../src/grammars/jsdocGrammar'
 import { Parser } from '../src/Parser'
-import { Grammar } from '../src/grammars/Grammar'
+import { type Grammar } from '../src/grammars/Grammar'
 
 import { createObjectParslet } from '../src/parslets/ObjectParslet'
-import { RootResult } from '../src/result/RootResult'
+import { type RootResult } from '../src/result/RootResult'
 import { Lexer } from '../src/lexer/Lexer'
 
 describe('`ObjectParslet`', () => {
@@ -53,7 +53,6 @@ describe('`ObjectParslet`', () => {
             quote: undefined
           },
           optional: false,
-          variadic: false,
           readonly: false,
           right: undefined,
           type: 'JsdocTypeObjectField'

--- a/test/assertTypes.spec.ts
+++ b/test/assertTypes.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { assertRootResult, assertNumberOrVariadicNameResult, assertPlainKeyValueResult } from '../src/assertTypes'
-import { NonRootResult } from '../src'
+import { type NonRootResult } from '../src'
 
 describe('assertTypes', () => {
   it('should see `assertRootResult` throw with an undefined result', () => {
@@ -36,7 +36,7 @@ describe('assertTypes', () => {
     }
     expect(() => {
       assertPlainKeyValueResult(objectWithKeyValue)
-    }).to.throw('Expecting no left side expression.')
+    }).to.throw('Unexpected type: \'JsdocTypeJsdocObjectField\'.')
   })
 
   it('should see `assertNumberOrVariadicNameResult` throw with a non-name `JsdocTypeVariadic`', () => {

--- a/test/assertTypes.spec.ts
+++ b/test/assertTypes.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
-import { assertRootResult, assertPlainKeyValueResult, assertNumberOrVariadicNameResult } from '../src/assertTypes'
-import { IntermediateResult } from '../src/result/IntermediateResult'
+import { assertRootResult, assertNumberOrVariadicNameResult, assertPlainKeyValueResult } from '../src/assertTypes'
+import { NonRootResult } from '../src'
 
 describe('assertTypes', () => {
   it('should see `assertRootResult` throw with an undefined result', () => {
@@ -10,43 +10,32 @@ describe('assertTypes', () => {
   })
 
   it('should see `assertPlainKeyValueResult` throw with a left side `JsdocTypeKeyValue` expression ``', () => {
-    const objectWithKeyValue = {
-      type: 'JsdocTypeObject',
-      meta: {
-        separator: 'comma'
-      },
-      elements: [
-        {
-          type: 'JsdocTypeKeyValue',
-          left: {
-            type: 'JsdocTypeGeneric',
-            left: {
-              type: 'JsdocTypeName',
-              value: 'Array'
-            },
-            elements: [
-              {
-                type: 'JsdocTypeName',
-                value: 'string'
-              }
-            ],
-            meta: {
-              brackets: 'angle',
-              dot: true
-            }
-          },
-          right: {
+    const objectWithKeyValue: NonRootResult = {
+      type: 'JsdocTypeJsdocObjectField',
+      left: {
+        type: 'JsdocTypeGeneric',
+        left: {
+          type: 'JsdocTypeName',
+          value: 'Array'
+        },
+        elements: [
+          {
             type: 'JsdocTypeName',
-            value: 'number'
-          },
-          meta: {
-            hasLeftSideExpression: true
+            value: 'string'
           }
+        ],
+        meta: {
+          brackets: 'angle',
+          dot: true
         }
-      ]
+      },
+      right: {
+        type: 'JsdocTypeName',
+        value: 'number'
+      }
     }
     expect(() => {
-      assertPlainKeyValueResult(objectWithKeyValue.elements[0] as IntermediateResult)
+      assertPlainKeyValueResult(objectWithKeyValue)
     }).to.throw('Expecting no left side expression.')
   })
 

--- a/test/fixtures/catharsis/functionType.spec.ts
+++ b/test/fixtures/catharsis/functionType.spec.ts
@@ -233,8 +233,8 @@ describe('catharsis function type tests', () => {
       jtp: {
         closure: 'closure',
         jsdoc: 'jsdoc',
-        typescript: 'typescript',
-        permissive: 'closure'
+        permissive: 'closure',
+        typescript: 'typescript'
       }
     })
   })
@@ -246,13 +246,8 @@ describe('catharsis function type tests', () => {
       expected: {
         parameters: [
           {
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             type: 'JsdocTypeKeyValue',
             key: 'this',
-            readonly: false,
             optional: false,
             variadic: false,
             right: {
@@ -312,15 +307,10 @@ describe('catharsis function type tests', () => {
       expected: {
         parameters: [
           {
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             type: 'JsdocTypeKeyValue',
-            key: 'this',
-            readonly: false,
             optional: false,
             variadic: false,
+            key: 'this',
             right: {
               left: {
                 left: {
@@ -384,14 +374,9 @@ describe('catharsis function type tests', () => {
         parameters: [
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
             optional: false,
             variadic: false,
             key: 'new',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               left: {
                 left: {
@@ -451,13 +436,8 @@ describe('catharsis function type tests', () => {
           {
             type: 'JsdocTypeKeyValue',
             key: 'new',
-            readonly: false,
             optional: false,
             variadic: false,
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               left: {
                 left: {
@@ -520,14 +500,9 @@ describe('catharsis function type tests', () => {
         parameters: [
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
+            key: 'new',
             optional: false,
             variadic: false,
-            key: 'new',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               left: {
                 left: {
@@ -557,14 +532,9 @@ describe('catharsis function type tests', () => {
           },
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
+            key: 'this',
             optional: false,
             variadic: false,
-            key: 'this',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               left: {
                 value: 'goog',
@@ -771,14 +741,9 @@ describe('catharsis function type tests', () => {
           parameters: [
             {
               type: 'JsdocTypeKeyValue',
-              readonly: false,
+              key: 'new',
               optional: false,
               variadic: false,
-              key: 'new',
-              meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
-              },
               right: {
                 type: 'JsdocTypeName',
                 value: 'Master'
@@ -786,14 +751,9 @@ describe('catharsis function type tests', () => {
             },
             {
               type: 'JsdocTypeKeyValue',
-              readonly: false,
+              key: 'this',
               optional: false,
               variadic: false,
-              key: 'this',
-              meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
-              },
               right: {
                 type: 'JsdocTypeName',
                 value: 'Everyone'
@@ -871,14 +831,9 @@ describe('catharsis function type tests', () => {
           parameters: [
             {
               type: 'JsdocTypeKeyValue',
-              readonly: false,
+              key: 'new',
               optional: false,
               variadic: false,
-              key: 'new',
-              meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
-              },
               right: {
                 type: 'JsdocTypeName',
                 value: 'Master'
@@ -886,14 +841,9 @@ describe('catharsis function type tests', () => {
             },
             {
               type: 'JsdocTypeKeyValue',
-              readonly: false,
+              key: 'this',
               optional: false,
               variadic: false,
-              key: 'this',
-              meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
-              },
               right: {
                 type: 'JsdocTypeName',
                 value: 'Everyone'
@@ -1147,14 +1097,9 @@ describe('catharsis function type tests', () => {
         parameters: [
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
+            key: 'this',
             optional: false,
             variadic: false,
-            key: 'this',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               type: 'JsdocTypeName',
               value: 'Object'
@@ -1208,14 +1153,9 @@ describe('catharsis function type tests', () => {
         parameters: [
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
+            key: 'this',
             optional: false,
             variadic: false,
-            key: 'this',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               element: {
                 type: 'JsdocTypeUnion',
@@ -1282,14 +1222,9 @@ describe('catharsis function type tests', () => {
           parameters: [
             {
               type: 'JsdocTypeKeyValue',
-              readonly: false,
+              key: 'new',
               optional: false,
               variadic: false,
-              key: 'new',
-              meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
-              },
               right: {
                 type: 'JsdocTypeName',
                 value: 'Array'
@@ -1319,14 +1254,9 @@ describe('catharsis function type tests', () => {
           parameters: [
             {
               type: 'JsdocTypeKeyValue',
-              readonly: false,
+              key: 'new',
               optional: false,
               variadic: false,
-              key: 'new',
-              meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
-              },
               right: {
                 type: 'JsdocTypeName',
                 value: 'Array'
@@ -1383,14 +1313,9 @@ describe('catharsis function type tests', () => {
         parameters: [
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
+            key: 'new',
             optional: false,
             variadic: false,
-            key: 'new',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               type: 'JsdocTypeName',
               value: 'Boolean'
@@ -1515,14 +1440,9 @@ describe('catharsis function type tests', () => {
         parameters: [
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
+            key: 'this',
             optional: false,
             variadic: false,
-            key: 'this',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               type: 'JsdocTypeName',
               value: 'Date'

--- a/test/fixtures/catharsis/jsdoc.spec.ts
+++ b/test/fixtures/catharsis/jsdoc.spec.ts
@@ -922,7 +922,6 @@ describe('catharsis jsdoc tests', () => {
             type: 'JsdocTypeObjectField',
             key: 'undefinedHTML',
             optional: false,
-            variadic: false,
             readonly: false,
             meta: {
               quote: undefined
@@ -977,7 +976,6 @@ describe('catharsis jsdoc tests', () => {
             type: 'JsdocTypeObjectField',
             key: 'foo',
             optional: false,
-            variadic: false,
             readonly: false,
             meta: {
               quote: undefined
@@ -1023,7 +1021,6 @@ describe('catharsis jsdoc tests', () => {
             type: 'JsdocTypeObjectField',
             key: 'foo',
             optional: false,
-            variadic: false,
             readonly: false,
             meta: {
               quote: undefined

--- a/test/fixtures/catharsis/jsdoc.spec.ts
+++ b/test/fixtures/catharsis/jsdoc.spec.ts
@@ -812,7 +812,7 @@ describe('catharsis jsdoc tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
+            type: 'JsdocTypeJsdocObjectField',
             left: {
               type: 'JsdocTypeGeneric',
               elements: [
@@ -833,9 +833,6 @@ describe('catharsis jsdoc tests', () => {
             right: {
               type: 'JsdocTypeName',
               value: 'number'
-            },
-            meta: {
-              hasLeftSideExpression: true
             }
           }
         ]
@@ -867,7 +864,7 @@ describe('catharsis jsdoc tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
+            type: 'JsdocTypeJsdocObjectField',
             left: {
               type: 'JsdocTypeParenthesis',
               element: {
@@ -891,9 +888,6 @@ describe('catharsis jsdoc tests', () => {
             right: {
               type: 'JsdocTypeName',
               value: 'number'
-            },
-            meta: {
-              hasLeftSideExpression: true
             }
           }
         ]
@@ -925,14 +919,13 @@ describe('catharsis jsdoc tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
+            type: 'JsdocTypeObjectField',
+            key: 'undefinedHTML',
             optional: false,
             variadic: false,
-            key: 'undefinedHTML',
+            readonly: false,
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             },
             right: {
               type: 'JsdocTypeParenthesis',
@@ -981,14 +974,13 @@ describe('catharsis jsdoc tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
+            type: 'JsdocTypeObjectField',
+            key: 'foo',
             optional: false,
             variadic: false,
-            key: 'foo',
+            readonly: false,
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             },
             right: {
               type: 'JsdocTypeFunction',
@@ -1028,14 +1020,13 @@ describe('catharsis jsdoc tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
+            type: 'JsdocTypeObjectField',
+            key: 'foo',
             optional: false,
             variadic: false,
-            key: 'foo',
+            readonly: false,
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             },
             right: {
               type: 'JsdocTypeFunction',
@@ -1104,14 +1095,9 @@ describe('catharsis jsdoc tests', () => {
           parameters: [
             {
               type: 'JsdocTypeKeyValue',
-              readonly: false,
+              key: 'this',
               optional: false,
               variadic: false,
-              key: 'this',
-              meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
-              },
               right: {
                 left: {
                   left: {

--- a/test/fixtures/catharsis/recordType.spec.ts
+++ b/test/fixtures/catharsis/recordType.spec.ts
@@ -45,7 +45,6 @@ describe('catharsis record type tests', () => {
               quote: undefined
             },
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeName',
@@ -90,7 +89,6 @@ describe('catharsis record type tests', () => {
                 quote: undefined
               },
               optional: false,
-              variadic: false,
               readonly: false,
               right: {
                 type: 'JsdocTypeName',
@@ -140,7 +138,6 @@ describe('catharsis record type tests', () => {
                 quote: undefined
               },
               optional: false,
-              variadic: false,
               readonly: false,
               right: {
                 type: 'JsdocTypeName',
@@ -189,7 +186,6 @@ describe('catharsis record type tests', () => {
                 quote: undefined
               },
               optional: false,
-              variadic: false,
               readonly: false,
               right: {
                 type: 'JsdocTypeName',
@@ -238,7 +234,6 @@ describe('catharsis record type tests', () => {
                 quote: undefined
               },
               optional: false,
-              variadic: false,
               readonly: false,
               right: {
                 type: 'JsdocTypeName',
@@ -285,7 +280,6 @@ describe('catharsis record type tests', () => {
               quote: undefined
             },
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeName',
@@ -297,7 +291,6 @@ describe('catharsis record type tests', () => {
             key: 'myObject',
             right: undefined,
             optional: false,
-            variadic: false,
             readonly: false,
             meta: {
               quote: undefined
@@ -339,7 +332,6 @@ describe('catharsis record type tests', () => {
               quote: undefined
             },
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeName',
@@ -353,7 +345,6 @@ describe('catharsis record type tests', () => {
               quote: undefined
             },
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeName',
@@ -396,7 +387,6 @@ describe('catharsis record type tests', () => {
               quote: undefined
             },
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeGeneric',
@@ -453,7 +443,6 @@ describe('catharsis record type tests', () => {
               quote: undefined
             },
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeParenthesis',
@@ -512,7 +501,6 @@ describe('catharsis record type tests', () => {
               quote: undefined
             },
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeName',
@@ -555,7 +543,6 @@ describe('catharsis record type tests', () => {
               quote: undefined
             },
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeName',
@@ -598,7 +585,6 @@ describe('catharsis record type tests', () => {
               quote: undefined
             },
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeName',
@@ -641,7 +627,6 @@ describe('catharsis record type tests', () => {
               quote: undefined
             },
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeName',

--- a/test/fixtures/catharsis/recordType.spec.ts
+++ b/test/fixtures/catharsis/recordType.spec.ts
@@ -39,15 +39,14 @@ describe('catharsis record type tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
-            optional: false,
-            variadic: false,
+            type: 'JsdocTypeObjectField',
             key: 'myNum',
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             },
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeName',
               value: 'number'
@@ -85,15 +84,14 @@ describe('catharsis record type tests', () => {
           },
           elements: [
             {
-              type: 'JsdocTypeKeyValue',
-              readonly: false,
-              optional: false,
-              variadic: false,
+              type: 'JsdocTypeObjectField',
               key: 'myNum',
               meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
+                quote: undefined
               },
+              optional: false,
+              variadic: false,
+              readonly: false,
               right: {
                 type: 'JsdocTypeName',
                 value: 'number'
@@ -136,15 +134,14 @@ describe('catharsis record type tests', () => {
           },
           elements: [
             {
-              type: 'JsdocTypeKeyValue',
-              readonly: false,
-              optional: false,
-              variadic: false,
+              type: 'JsdocTypeObjectField',
               key: 'myNum',
               meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
+                quote: undefined
               },
+              optional: false,
+              variadic: false,
+              readonly: false,
               right: {
                 type: 'JsdocTypeName',
                 value: 'number'
@@ -186,15 +183,14 @@ describe('catharsis record type tests', () => {
           },
           elements: [
             {
-              type: 'JsdocTypeKeyValue',
-              readonly: false,
-              optional: false,
-              variadic: false,
+              type: 'JsdocTypeObjectField',
               key: 'myNum',
               meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
+                quote: undefined
               },
+              optional: false,
+              variadic: false,
+              readonly: false,
               right: {
                 type: 'JsdocTypeName',
                 value: 'number'
@@ -236,15 +232,14 @@ describe('catharsis record type tests', () => {
           },
           elements: [
             {
-              type: 'JsdocTypeKeyValue',
-              readonly: false,
-              optional: false,
-              variadic: false,
+              type: 'JsdocTypeObjectField',
               key: 'myNum',
               meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
+                quote: undefined
               },
+              optional: false,
+              variadic: false,
+              readonly: false,
               right: {
                 type: 'JsdocTypeName',
                 value: 'number'
@@ -284,30 +279,28 @@ describe('catharsis record type tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
-            optional: false,
-            variadic: false,
+            type: 'JsdocTypeObjectField',
             key: 'myNum',
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             },
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeName',
               value: 'number'
             }
           },
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
+            type: 'JsdocTypeObjectField',
             key: 'myObject',
             right: undefined,
             optional: false,
             variadic: false,
+            readonly: false,
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             }
           }
         ]
@@ -340,30 +333,28 @@ describe('catharsis record type tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
-            optional: false,
-            variadic: false,
+            type: 'JsdocTypeObjectField',
             key: 'myNum',
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             },
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeName',
               value: 'number'
             }
           },
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
+            type: 'JsdocTypeObjectField',
             key: 'myObject',
+            meta: {
+              quote: undefined
+            },
             optional: false,
             variadic: false,
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
+            readonly: false,
             right: {
               type: 'JsdocTypeName',
               value: 'string'
@@ -399,15 +390,14 @@ describe('catharsis record type tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
-            optional: false,
-            variadic: false,
+            type: 'JsdocTypeObjectField',
             key: 'myArray',
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             },
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeGeneric',
               left: {
@@ -457,15 +447,14 @@ describe('catharsis record type tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
-            optional: false,
-            variadic: false,
+            type: 'JsdocTypeObjectField',
             key: 'myKey',
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             },
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeParenthesis',
               element: {
@@ -517,15 +506,14 @@ describe('catharsis record type tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
-            optional: false,
-            variadic: false,
+            type: 'JsdocTypeObjectField',
             key: 'continue',
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             },
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeName',
               value: 'string'
@@ -561,15 +549,14 @@ describe('catharsis record type tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
-            optional: false,
-            variadic: false,
+            type: 'JsdocTypeObjectField',
             key: 'class',
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             },
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeName',
               value: 'string'
@@ -605,15 +592,14 @@ describe('catharsis record type tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
-            optional: false,
-            variadic: false,
+            type: 'JsdocTypeObjectField',
             key: 'true',
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             },
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeName',
               value: 'string'
@@ -649,15 +635,14 @@ describe('catharsis record type tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
-            optional: false,
-            variadic: false,
+            type: 'JsdocTypeObjectField',
             key: '0',
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             },
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeName',
               value: 'string'

--- a/test/fixtures/catharsis/typeApplication.spec.ts
+++ b/test/fixtures/catharsis/typeApplication.spec.ts
@@ -196,7 +196,6 @@ describe('catharsis type application tests', () => {
                             quote: undefined
                           },
                           optional: false,
-                          variadic: false,
                           readonly: false,
                           right: {
                             type: 'JsdocTypeName',
@@ -300,7 +299,6 @@ describe('catharsis type application tests', () => {
                 type: 'JsdocTypeObjectField',
                 key: 'length',
                 optional: false,
-                variadic: false,
                 readonly: false,
                 right: undefined,
                 meta: {

--- a/test/fixtures/catharsis/typeApplication.spec.ts
+++ b/test/fixtures/catharsis/typeApplication.spec.ts
@@ -190,15 +190,14 @@ describe('catharsis type application tests', () => {
                       },
                       elements: [
                         {
-                          type: 'JsdocTypeKeyValue',
-                          readonly: false,
-                          optional: false,
-                          variadic: false,
+                          type: 'JsdocTypeObjectField',
                           key: 'myKey',
                           meta: {
-                            quote: undefined,
-                            hasLeftSideExpression: false
+                            quote: undefined
                           },
+                          optional: false,
+                          variadic: false,
+                          readonly: false,
                           right: {
                             type: 'JsdocTypeName',
                             value: 'Error'
@@ -237,14 +236,9 @@ describe('catharsis type application tests', () => {
                   parameters: [
                     {
                       type: 'JsdocTypeKeyValue',
-                      readonly: false,
+                      key: 'new',
                       optional: false,
                       variadic: false,
-                      key: 'new',
-                      meta: {
-                        quote: undefined,
-                        hasLeftSideExpression: false
-                      },
                       right: {
                         type: 'JsdocTypeName',
                         value: 'foo'
@@ -303,15 +297,14 @@ describe('catharsis type application tests', () => {
             },
             elements: [
               {
-                type: 'JsdocTypeKeyValue',
-                readonly: false,
+                type: 'JsdocTypeObjectField',
                 key: 'length',
-                right: undefined,
                 optional: false,
                 variadic: false,
+                readonly: false,
+                right: undefined,
                 meta: {
-                  quote: undefined,
-                  hasLeftSideExpression: false
+                  quote: undefined
                 }
               }
             ]

--- a/test/fixtures/misc/KeyValueParslet.spec.ts
+++ b/test/fixtures/misc/KeyValueParslet.spec.ts
@@ -14,7 +14,6 @@ describe('variadic tests', () => {
             type: 'JsdocTypeObjectField',
             key: 'abc',
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeName',

--- a/test/fixtures/misc/KeyValueParslet.spec.ts
+++ b/test/fixtures/misc/KeyValueParslet.spec.ts
@@ -11,18 +11,17 @@ describe('variadic tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
+            type: 'JsdocTypeObjectField',
             key: 'abc',
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeName',
               value: 'string'
             },
-            optional: false,
-            readonly: false,
-            variadic: false,
             meta: {
-              quote: 'double',
-              hasLeftSideExpression: false
+              quote: 'double'
             }
           }
         ]

--- a/test/fixtures/misc/ObjectParslet.spec.ts
+++ b/test/fixtures/misc/ObjectParslet.spec.ts
@@ -11,15 +11,14 @@ describe('`ObjectParslet`', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
+            type: 'JsdocTypeObjectField',
             right: undefined,
             key: '123',
             optional: false,
-            readonly: false,
             variadic: false,
+            readonly: false,
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             }
           }
         ]
@@ -42,15 +41,14 @@ describe('`ObjectParslet`', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
+            type: 'JsdocTypeObjectField',
             right: undefined,
             key: 'abc',
             optional: false,
-            readonly: false,
             variadic: false,
+            readonly: false,
             meta: {
-              quote: 'double',
-              hasLeftSideExpression: false
+              quote: 'double'
             }
           }
         ]

--- a/test/fixtures/misc/ObjectParslet.spec.ts
+++ b/test/fixtures/misc/ObjectParslet.spec.ts
@@ -15,7 +15,6 @@ describe('`ObjectParslet`', () => {
             right: undefined,
             key: '123',
             optional: false,
-            variadic: false,
             readonly: false,
             meta: {
               quote: undefined
@@ -45,7 +44,6 @@ describe('`ObjectParslet`', () => {
             right: undefined,
             key: 'abc',
             optional: false,
-            variadic: false,
             readonly: false,
             meta: {
               quote: 'double'

--- a/test/fixtures/typescript/arrowFunction.spec.ts
+++ b/test/fixtures/typescript/arrowFunction.spec.ts
@@ -9,14 +9,9 @@ describe('typescript arrow function tests', () => {
         parameters: [
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
+            key: 'x',
             optional: false,
             variadic: false,
-            key: 'x',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               type: 'JsdocTypeAny'
             }
@@ -53,14 +48,9 @@ describe('typescript arrow function tests', () => {
         parameters: [
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
+            key: 'x',
             optional: false,
             variadic: false,
-            key: 'x',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               type: 'JsdocTypeName',
               value: 'number'
@@ -99,14 +89,9 @@ describe('typescript arrow function tests', () => {
         parameters: [
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
+            key: 'x',
             optional: false,
             variadic: false,
-            key: 'x',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               type: 'JsdocTypeName',
               value: 'number'
@@ -114,14 +99,9 @@ describe('typescript arrow function tests', () => {
           },
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
+            key: 'y',
             optional: false,
             variadic: false,
-            key: 'y',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               type: 'JsdocTypeName',
               value: 'string'
@@ -129,14 +109,9 @@ describe('typescript arrow function tests', () => {
           },
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
+            key: 'z',
             optional: false,
             variadic: false,
-            key: 'z',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               type: 'JsdocTypeName',
               value: 'Class'
@@ -285,14 +260,9 @@ describe('typescript arrow function tests', () => {
         parameters: [
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
+            key: 'arrow',
             optional: false,
             variadic: false,
-            key: 'arrow',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               type: 'JsdocTypeName',
               value: 'Function'
@@ -300,14 +270,9 @@ describe('typescript arrow function tests', () => {
           },
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
+            key: 'with',
             optional: false,
             variadic: false,
-            key: 'with',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               type: 'JsdocTypeName',
               value: 'TrailingComma'
@@ -456,14 +421,9 @@ describe('typescript arrow function tests', () => {
         parameters: [
           {
             type: 'JsdocTypeKeyValue',
-            readonly: false,
+            key: 'a',
             optional: false,
             variadic: false,
-            key: 'a',
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               type: 'JsdocTypeName',
               value: 'number'
@@ -475,14 +435,9 @@ describe('typescript arrow function tests', () => {
           parameters: [
             {
               type: 'JsdocTypeKeyValue',
-              readonly: false,
+              key: 'b',
               optional: false,
               variadic: false,
-              key: 'b',
-              meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
-              },
               right: {
                 type: 'JsdocTypeName',
                 value: 'string'
@@ -577,7 +532,10 @@ describe('typescript arrow function tests', () => {
         type: 'JsdocTypeObject',
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
+            type: 'JsdocTypeObjectField',
+            optional: false,
+            variadic: false,
+            readonly: false,
             key: 'x',
             right: {
               type: 'JsdocTypeFunction',
@@ -590,28 +548,23 @@ describe('typescript arrow function tests', () => {
               constructor: false,
               parenthesis: true
             },
-            optional: false,
-            readonly: false,
-            variadic: false,
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             }
           },
           {
-            type: 'JsdocTypeKeyValue',
+            type: 'JsdocTypeObjectField',
             key: 'y',
+            meta: {
+              quote: undefined
+            },
+            optional: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeName',
               value: 'string'
             },
-            optional: false,
-            readonly: false,
-            variadic: false,
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            }
+            variadic: false
           }
         ],
         meta: {

--- a/test/fixtures/typescript/arrowFunction.spec.ts
+++ b/test/fixtures/typescript/arrowFunction.spec.ts
@@ -534,7 +534,6 @@ describe('typescript arrow function tests', () => {
           {
             type: 'JsdocTypeObjectField',
             optional: false,
-            variadic: false,
             readonly: false,
             key: 'x',
             right: {
@@ -563,14 +562,49 @@ describe('typescript arrow function tests', () => {
             right: {
               type: 'JsdocTypeName',
               value: 'string'
-            },
-            variadic: false
+            }
           }
         ],
         meta: {
           separator: 'comma'
         }
       }
+    })
+  })
+
+  describe('optional parameters for functions', () => {
+    testFixture({
+      input: '(param1: string, param2?: string) => number',
+      expected: {
+        type: 'JsdocTypeFunction',
+        arrow: true,
+        constructor: false,
+        parenthesis: true,
+        parameters: [{
+          type: 'JsdocTypeKeyValue',
+          key: 'param1',
+          right: {
+            type: 'JsdocTypeName',
+            value: 'string'
+          },
+          optional: false,
+          variadic: false
+        }, {
+          type: 'JsdocTypeKeyValue',
+          key: 'param2',
+          right: {
+            type: 'JsdocTypeName',
+            value: 'string'
+          },
+          optional: true,
+          variadic: false
+        }],
+        returnType: {
+          type: 'JsdocTypeName',
+          value: 'number'
+        }
+      },
+      modes: ['typescript']
     })
   })
 })

--- a/test/fixtures/typescript/functions.spec.ts
+++ b/test/fixtures/typescript/functions.spec.ts
@@ -57,9 +57,6 @@ describe('typescript function test', () => {
         parameters: [{
           type: 'JsdocTypeKeyValue',
           key: 'args',
-          variadic: true,
-          optional: false,
-          readonly: false,
           right: {
             type: 'JsdocTypeGeneric',
             left: {
@@ -75,10 +72,8 @@ describe('typescript function test', () => {
               dot: false
             }
           },
-          meta: {
-            quote: undefined,
-            hasLeftSideExpression: false
-          }
+          optional: false,
+          variadic: true
         }],
         returnType: {
           type: 'JsdocTypeName',

--- a/test/fixtures/typescript/intersection.spec.ts
+++ b/test/fixtures/typescript/intersection.spec.ts
@@ -160,14 +160,9 @@ describe('typescript intersection tests', () => {
             parameters: [
               {
                 type: 'JsdocTypeKeyValue',
-                readonly: false,
+                key: 'a',
                 optional: false,
                 variadic: false,
-                key: 'a',
-                meta: {
-                  quote: undefined,
-                  hasLeftSideExpression: false
-                },
                 right: {
                   type: 'JsdocTypeName',
                   value: 'string'

--- a/test/fixtures/typescript/objects.spec.ts
+++ b/test/fixtures/typescript/objects.spec.ts
@@ -15,7 +15,6 @@ describe('typescript objects tests', () => {
             type: 'JsdocTypeObjectField',
             key: 'object',
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeName',
@@ -61,7 +60,6 @@ describe('typescript objects tests', () => {
               type: 'JsdocTypeObjectField',
               key: 'object',
               optional: true,
-              variadic: false,
               readonly: false,
               meta: {
                 quote: undefined
@@ -75,7 +73,6 @@ describe('typescript objects tests', () => {
               type: 'JsdocTypeObjectField',
               key: 'key',
               optional: false,
-              variadic: false,
               readonly: false,
               meta: {
                 quote: undefined
@@ -114,7 +111,6 @@ describe('typescript objects tests', () => {
               type: 'JsdocTypeObjectField',
               key: 'key',
               optional: false,
-              variadic: false,
               readonly: false,
               meta: {
                 quote: undefined
@@ -158,7 +154,6 @@ describe('typescript objects tests', () => {
             type: 'JsdocTypeObjectField',
             key: 'message',
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeUnion',
@@ -210,7 +205,6 @@ describe('typescript objects tests', () => {
             type: 'JsdocTypeObjectField',
             key: 'message',
             optional: true,
-            variadic: false,
             readonly: false,
             right: undefined,
             meta: {
@@ -248,7 +242,6 @@ describe('typescript objects tests', () => {
             type: 'JsdocTypeObjectField',
             key: 'module',
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeName',
@@ -285,7 +278,6 @@ describe('typescript objects tests', () => {
             type: 'JsdocTypeObjectField',
             key: 'range',
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeName',
@@ -299,7 +291,6 @@ describe('typescript objects tests', () => {
             type: 'JsdocTypeObjectField',
             key: 'loc',
             optional: false,
-            variadic: false,
             readonly: false,
             right: {
               type: 'JsdocTypeName',

--- a/test/fixtures/typescript/objects.spec.ts
+++ b/test/fixtures/typescript/objects.spec.ts
@@ -12,18 +12,17 @@ describe('typescript objects tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
+            type: 'JsdocTypeObjectField',
             key: 'object',
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeName',
               value: 'string'
             },
-            optional: false,
-            readonly: false,
-            variadic: false,
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             }
           }
         ]
@@ -59,34 +58,32 @@ describe('typescript objects tests', () => {
           },
           elements: [
             {
-              type: 'JsdocTypeKeyValue',
-              readonly: false,
+              type: 'JsdocTypeObjectField',
               key: 'object',
+              optional: true,
+              variadic: false,
+              readonly: false,
               meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
+                quote: undefined
               },
               right: {
                 type: 'JsdocTypeName',
                 value: 'string'
-              },
-              optional: true,
-              variadic: false
+              }
             },
             {
-              type: 'JsdocTypeKeyValue',
-              readonly: false,
+              type: 'JsdocTypeObjectField',
               key: 'key',
+              optional: false,
+              variadic: false,
+              readonly: false,
               meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
+                quote: undefined
               },
               right: {
                 type: 'JsdocTypeName',
                 value: 'string'
-              },
-              optional: false,
-              variadic: false
+              }
             }
           ]
         },
@@ -97,7 +94,7 @@ describe('typescript objects tests', () => {
           },
           elements: [
             {
-              type: 'JsdocTypeKeyValue',
+              type: 'JsdocTypeJsdocObjectField',
               left: {
                 type: 'JsdocTypeNullable',
                 element: {
@@ -111,25 +108,21 @@ describe('typescript objects tests', () => {
               right: {
                 type: 'JsdocTypeName',
                 value: 'string'
-              },
-              meta: {
-                hasLeftSideExpression: true
               }
             },
             {
-              type: 'JsdocTypeKeyValue',
-              readonly: false,
+              type: 'JsdocTypeObjectField',
               key: 'key',
+              optional: false,
+              variadic: false,
+              readonly: false,
               meta: {
-                quote: undefined,
-                hasLeftSideExpression: false
+                quote: undefined
               },
               right: {
                 type: 'JsdocTypeName',
                 value: 'string'
-              },
-              optional: false,
-              variadic: false
+              }
             }
           ]
         }
@@ -162,9 +155,11 @@ describe('typescript objects tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
+            type: 'JsdocTypeObjectField',
             key: 'message',
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeUnion',
               elements: [
@@ -177,11 +172,8 @@ describe('typescript objects tests', () => {
                 }
               ]
             },
-            optional: false,
-            variadic: false,
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             }
           }
         ]
@@ -215,15 +207,14 @@ describe('typescript objects tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
-            readonly: false,
+            type: 'JsdocTypeObjectField',
             key: 'message',
-            right: undefined,
             optional: true,
             variadic: false,
+            readonly: false,
+            right: undefined,
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             }
           }
         ]
@@ -254,18 +245,17 @@ describe('typescript objects tests', () => {
         type: 'JsdocTypeObject',
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
+            type: 'JsdocTypeObjectField',
             key: 'module',
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeName',
               value: 'type'
             },
-            optional: false,
-            readonly: false,
-            variadic: false,
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             }
           }
         ],
@@ -276,10 +266,10 @@ describe('typescript objects tests', () => {
     })
   })
 
-  describe('linebreaks can be seperators', () => {
+  describe('linebreaks can be separators', () => {
     testFixture({
       input:
-`{
+        `{
   range: boolean
   loc: boolean
 }`,
@@ -292,37 +282,81 @@ describe('typescript objects tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
+            type: 'JsdocTypeObjectField',
             key: 'range',
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeName',
               value: 'boolean'
             },
-            optional: false,
-            readonly: false,
-            variadic: false,
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             }
           },
           {
-            type: 'JsdocTypeKeyValue',
+            type: 'JsdocTypeObjectField',
             key: 'loc',
+            optional: false,
+            variadic: false,
+            readonly: false,
             right: {
               type: 'JsdocTypeName',
               value: 'boolean'
             },
-            optional: false,
-            readonly: false,
-            variadic: false,
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             }
           }
         ]
       }
     })
   })
+
+  // describe('multiple levels of square brackets', () => {
+  //   testFixture({
+  //     input: 'obj["level1"]["level2"]',
+  //     modes: ['typescript']
+  //   })
+  // })
+
+  // describe('index signatures', () => {
+  //   testFixture({
+  //     input: '{ [key: string]: number }',
+  //     modes: ['typescript'],
+  //     expected: {
+  //       type: 'JsdocTypeObject',
+  //       meta: {
+  //         separator: undefined
+  //       },
+  //       elements: [
+  //         {
+  //           type: 'JsdocTypeObjectField',
+  //           key: {
+  //             type: 'JsdocTypeIndexSignature',
+  //             element: {
+  //               type: 'JsdocTypeObjectField',
+  //               key: 'key',
+  //               right: {
+  //                 type: 'JsdocTypeName',
+  //                 value: 'string'
+  //               },
+  //               meta: {
+  //                 quote: undefined
+  //               }
+  //             }
+  //           },
+  //           right: {
+  //             type: 'JsdocTypeName',
+  //             value: 'number'
+  //           },
+  //           meta: {
+  //             quote: undefined
+  //           }
+  //         }
+  //       ]
+  //     }
+  //   })
+  // })
 })

--- a/test/fixtures/typescript/readonly.spec.ts
+++ b/test/fixtures/typescript/readonly.spec.ts
@@ -24,7 +24,6 @@ describe('typescript readonly tests', () => {
             key: 'x',
             readonly: true,
             optional: false,
-            variadic: false,
             right: {
               type: 'JsdocTypeName',
               value: 'number'

--- a/test/fixtures/typescript/readonly.spec.ts
+++ b/test/fixtures/typescript/readonly.spec.ts
@@ -20,18 +20,17 @@ describe('typescript readonly tests', () => {
         },
         elements: [
           {
-            type: 'JsdocTypeKeyValue',
+            type: 'JsdocTypeObjectField',
             key: 'x',
+            readonly: true,
+            optional: false,
+            variadic: false,
             right: {
               type: 'JsdocTypeName',
               value: 'number'
             },
-            optional: false,
-            readonly: true,
-            variadic: false,
             meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
+              quote: undefined
             }
           }
         ]

--- a/test/fixtures/typescript/tuple.spec.ts
+++ b/test/fixtures/typescript/tuple.spec.ts
@@ -620,12 +620,7 @@ describe('typescript tuple tests', () => {
             type: 'JsdocTypeKeyValue',
             key: 'a',
             optional: false,
-            readonly: false,
             variadic: false,
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               type: 'JsdocTypeName',
               value: 'string'
@@ -647,12 +642,7 @@ describe('typescript tuple tests', () => {
             type: 'JsdocTypeKeyValue',
             key: 'a',
             optional: false,
-            readonly: false,
             variadic: false,
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               type: 'JsdocTypeName',
               value: 'string'
@@ -662,12 +652,7 @@ describe('typescript tuple tests', () => {
             type: 'JsdocTypeKeyValue',
             key: 'b',
             optional: false,
-            readonly: false,
             variadic: false,
-            meta: {
-              quote: undefined,
-              hasLeftSideExpression: false
-            },
             right: {
               type: 'JsdocTypeName',
               value: 'number'

--- a/test/jtpTransform.spec.ts
+++ b/test/jtpTransform.spec.ts
@@ -2,10 +2,11 @@ import { expect } from 'chai'
 
 import { RootResult } from '../src/result/RootResult'
 import { jtpTransform } from '../src/index'
+import { JtpResult } from '../src/transforms/jtpTransform'
 
 describe('transform', () => {
   it('Gets transform for `JsdocTypeNamePath` with `property-brackets`', () => {
-    const expected = {
+    const expected: JtpResult = {
       hasEventPrefix: false,
       name: 'text',
       owner: {
@@ -15,7 +16,7 @@ describe('transform', () => {
       quoteStyle: 'double',
       type: 'MEMBER'
     }
-    const parseResult = {
+    const parseResult: RootResult = {
       type: 'JsdocTypeNamePath',
       left: {
         type: 'JsdocTypeName',
@@ -30,12 +31,12 @@ describe('transform', () => {
       },
       pathType: 'property-brackets'
     }
-    const xform = jtpTransform(parseResult as RootResult)
+    const xform = jtpTransform(parseResult)
     expect(xform).to.deep.equal(expected)
   })
 
   it('Gets transform for `JsdocTypeNamePath` with `property-brackets`', () => {
-    const expected = {
+    const expected: JtpResult = {
       hasEventPrefix: true,
       name: 'def',
       owner: {
@@ -45,7 +46,7 @@ describe('transform', () => {
       quoteStyle: 'none',
       type: 'INSTANCE_MEMBER'
     }
-    const parseResult = {
+    const parseResult: RootResult = {
       type: 'JsdocTypeNamePath',
       left: {
         type: 'JsdocTypeName',
@@ -55,16 +56,18 @@ describe('transform', () => {
         type: 'JsdocTypeSpecialNamePath',
         value: 'def',
         specialType: 'event',
-        meta: {}
+        meta: {
+          quote: undefined
+        }
       },
       pathType: 'instance'
     }
-    const xform = jtpTransform(parseResult as RootResult)
+    const xform = jtpTransform(parseResult)
     expect(xform).to.deep.equal(expected)
   })
 
   it('Gets transform for `JsdocTypeOptional` with prefix', () => {
-    const expected = {
+    const expected: JtpResult = {
       meta: {
         syntax: 'PREFIX_EQUAL_SIGN'
       },
@@ -74,7 +77,7 @@ describe('transform', () => {
         type: 'NAME'
       }
     }
-    const parseResult = {
+    const parseResult: RootResult = {
       type: 'JsdocTypeOptional',
       element: {
         type: 'JsdocTypeName',
@@ -84,30 +87,30 @@ describe('transform', () => {
         position: 'prefix'
       }
     }
-    const xform = jtpTransform(parseResult as RootResult)
+    const xform = jtpTransform(parseResult)
     expect(xform).to.deep.equal(expected)
   })
 
   it('Gets transform for empty `JsdocTypeVariadic`', () => {
-    const expected = {
+    const expected: JtpResult = {
       meta: {
         syntax: 'ONLY_DOTS'
       },
       type: 'VARIADIC'
     }
-    const parseResult = {
+    const parseResult: RootResult = {
       type: 'JsdocTypeVariadic',
       meta: {
         position: undefined,
         squareBrackets: false
       }
     }
-    const xform = jtpTransform(parseResult as RootResult)
+    const xform = jtpTransform(parseResult)
     expect(xform).to.deep.equal(expected)
   })
 
   it('Gets transform for suffix `JsdocTypeVariadic`', () => {
-    const expected = {
+    const expected: JtpResult = {
       meta: {
         syntax: 'SUFFIX_DOTS'
       },
@@ -117,7 +120,7 @@ describe('transform', () => {
         type: 'NAME'
       }
     }
-    const parseResult = {
+    const parseResult: RootResult = {
       type: 'JsdocTypeVariadic',
       element: {
         type: 'JsdocTypeName',
@@ -128,23 +131,23 @@ describe('transform', () => {
         squareBrackets: false
       }
     }
-    const xform = jtpTransform(parseResult as RootResult)
+    const xform = jtpTransform(parseResult)
     expect(xform).to.deep.equal(expected)
   })
 
   // Note: This does not seem possible through the normal generation of
   //   `JsdocTypeObject`
   it('Skips non-`JsdocTypeKeyValue` value', () => {
-    const expected = {
+    const expected: JtpResult = {
       entries: [],
       type: 'RECORD'
     }
 
-    const parseResult = {
+    const parseResult: RootResult = {
       type: 'JsdocTypeObject',
       elements: [
         {
-          // Type not allowed
+          // @ts-expect-error
           type: 'JsdocTypeNumber',
           value: 100
         }
@@ -153,14 +156,14 @@ describe('transform', () => {
         separator: undefined
       }
     }
-    const xform = jtpTransform(parseResult as RootResult)
+    const xform = jtpTransform(parseResult)
     expect(xform).to.deep.equal(expected)
   })
 
   // Note: This does not seem possible through the normal generation of
   //   `JsdocTypeFunction`
   it('Gets transform for suffix `JsdocTypeGeneric`', () => {
-    const expected = {
+    const expected: JtpResult = {
       type: 'GENERIC',
       subject: {
         name: 'Array',
@@ -176,7 +179,7 @@ describe('transform', () => {
         syntax: 'SQUARE_BRACKET'
       }
     }
-    const parseResult = {
+    const parseResult: RootResult = {
       type: 'JsdocTypeGeneric',
       left: {
         type: 'JsdocTypeName',
@@ -187,7 +190,8 @@ describe('transform', () => {
           type: 'JsdocTypeFunction',
           parameters: [],
           arrow: false,
-          parenthesis: false
+          parenthesis: false,
+          constructor: false
         }
       ],
       meta: {
@@ -195,19 +199,19 @@ describe('transform', () => {
         dot: false
       }
     }
-    const xform = jtpTransform(parseResult as RootResult)
+    const xform = jtpTransform(parseResult)
     expect(xform).to.deep.equal(expected)
   })
 
   it('Throws with `JsdocTypeKeyValue` and non-plain key', () => {
-    const parseResult = {
+    const parseResult: RootResult = {
       type: 'JsdocTypeObject',
       meta: {
         separator: 'comma'
       },
       elements: [
         {
-          type: 'JsdocTypeKeyValue',
+          type: 'JsdocTypeJsdocObjectField',
           left: {
             type: 'JsdocTypeGeneric',
             left: {
@@ -228,54 +232,50 @@ describe('transform', () => {
           right: {
             type: 'JsdocTypeName',
             value: 'number'
-          },
-          meta: {
-            hasLeftSideExpression: true
           }
         }
       ]
     }
 
     expect(() => {
-      jtpTransform(parseResult as RootResult)
+      jtpTransform(parseResult)
     }).to.throw('Keys may not be typed in jsdoctypeparser.')
   })
 
   it('Throws with `JsdocTypeSpecialNamePath` and external `specialType`', () => {
-    const parseResult = {
+    const parseResult: RootResult = {
       type: 'JsdocTypeSpecialNamePath',
       value: 'abc',
       specialType: 'external',
-      meta: {}
+      meta: {
+        quote: undefined
+      }
     }
 
     expect(() => {
-      jtpTransform(parseResult as RootResult)
+      jtpTransform(parseResult)
     }).to.throw('jsdoctypeparser does not support type external at this point.')
   })
 
   it('Throws with `JsdocTypeFunction` and `JsdocTypeKeyValue` with undefined `right`', () => {
-    const parseResult = {
+    const parseResult: RootResult = {
       type: 'JsdocTypeFunction',
       arrow: false,
       parenthesis: true,
+      constructor: false,
       parameters: [
         {
           type: 'JsdocTypeKeyValue',
           key: 'abc',
           right: undefined,
           optional: false,
-          readonly: false,
-          meta: {
-            quote: undefined,
-            hasLeftSideExpression: false
-          }
+          variadic: false
         }
       ]
     }
 
     expect(() => {
-      jtpTransform(parseResult as RootResult)
+      jtpTransform(parseResult)
     }).to.throw("Function parameter without ':' is not expected to be 'KEY_VALUE'")
   })
 })

--- a/test/traverse.spec.ts
+++ b/test/traverse.spec.ts
@@ -174,12 +174,7 @@ describe('traverse', () => {
       key: 'a',
       right: nameA,
       optional: false,
-      readonly: false,
-      variadic: false,
-      meta: {
-        quote: undefined,
-        hasLeftSideExpression: false
-      }
+      variadic: false
     }
 
     const keyValueB: KeyValueResult = {
@@ -187,12 +182,7 @@ describe('traverse', () => {
       key: 'b',
       right: nameB,
       optional: false,
-      readonly: false,
-      variadic: false,
-      meta: {
-        quote: undefined,
-        hasLeftSideExpression: false
-      }
+      variadic: false
     }
 
     const tuple: TupleResult = {


### PR DESCRIPTION
BREAKING CHANGES: `ObjectResult` no longer contains `KeyValueResult`, but uses the new types `ObjectFieldResult` and `JsdocObjectFieldResult`.

For mode `typescript` this basically means a simple rename of type `JsdocTypeKeyValue` to `JsdocTypeObjectField`: input: `{ key: string }`
before:
```
{
  "type": "JsdocTypeObject",
  "meta": {
    "separator": "comma"
  },
  "elements": [
    {
      "type": "JsdocTypeKeyValue",
      "key": "key",
      "right": {
        "type": "JsdocTypeName",
        "value": "string"
      },
      "optional": false,
      "readonly": false,
      "variadic": false,
      "meta": {
        "hasLeftSideExpression": false
      }
    }
  ]
}
```
after:
```
{
  "type": "JsdocTypeObject",
  "meta": {
    "separator": "comma"
  },
  "elements": [
    {
      "type": "JsdocTypeObjectField",
      "key": "key",
      "right": {
        "type": "JsdocTypeName",
        "value": "string"
      },
      "optional": false,
      "readonly": false,
      "variadic": false,
      "meta": {
        "quote": undefined
      }
    }
  ]
}
```

for `jsdoc` mode the `JsdocTypeKeyValue` can now be either `JsdocTypeObjectField` or `JsdocTypeJsdocObjectField`: input: `{ Array<string>: string }`
before:
```
{
  "type": "JsdocTypeObject",
  "meta": {
    "separator": "comma"
  },
  "elements": [
    {
      "type": "JsdocTypeKeyValue",
      "left": {
        "type": "JsdocTypeGeneric",
        "left": {
          "type": "JsdocTypeName",
          "value": "Array"
        },
        "elements": [
          {
            "type": "JsdocTypeName",
            "value": "string"
          }
        ],
        "meta": {
          "brackets": "angle",
          "dot": false
        }
      },
      "right": {
        "type": "JsdocTypeName",
        "value": "string"
      },
      "meta": {
        "hasLeftSideExpression": true
      }
    }
  ]
}
```
after:
```
{
  "type": "JsdocTypeObject",
  "meta": {
    "separator": "comma"
  },
  "elements": [
    {
      "type": "JsdocTypeJsdocObjectField",
      "left": {
        "type": "JsdocTypeGeneric",
        "left": {
          "type": "JsdocTypeName",
          "value": "Array"
        },
        "elements": [
          {
            "type": "JsdocTypeName",
            "value": "string"
          }
        ],
        "meta": {
          "brackets": "angle",
          "dot": false
        }
      },
      "right": {
        "type": "JsdocTypeName",
        "value": "string"
      }
    }
  ]
}
```