### PR TITLE
feat: add `JsdocTypeReadonlyArray` type

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@ This project works best with a test-driven design. This is a write-up of the nec
 For example let's say we want to add TypeScript predicates i.e. `@returns {x is string}`. To do that it makes sense to
 follow these steps:
 
-1. Add a new result type. In this case it is a `RootResult` which means that can appear as a root node of an AST. 
+1. Add a new result type. In this case it is a `RootResult` which means that can appear as a root node of an AST.
    It is important that we use a type that is not used yet and is prefixed with `JsdocType`. We choose `JsdocTypePredicate`.
    A predicate can have two child elements, we call them `left` and `right`. `left` always has to be a name.
    We add the following to the file `src/result/RootResult.ts`:
@@ -57,7 +57,7 @@ export interface PredicateResult {
 
 5. Specify visitor keys. This is the next type error that will occur in file `src/visitorKeys.ts`. These are the
    properties of our new type which should be visited by tree traversing functions. In our case these are `['left', 'right']`.
- 
+
 6. Add a test. To test we think about an example expression and how we expect it to be parsed. Then we specify these
    in a fixture test and use `testFixture` to do this. There the typing can guide us to fill all required fields.
    Check the [API docs](https://jsdoc-type-pratt-parser.github.io/jsdoc-type-pratt-parser/docs/interfaces/Fixture.html)
@@ -120,7 +120,7 @@ export const predicateParslet = composeParslet({
   precedence: Precedence.INFIX,
   accept: type => type === 'is',
   parseInfix: (parser, left) => {
-    
+
   }
 })
 ```
@@ -146,9 +146,9 @@ export const predicateParslet = composeParslet({
     if (left.type !== 'JsdocTypeName') {
       throw new UnexpectedTypeError(left, 'A TypeScript predicate always has to have a name on the left side.')
     }
-    
+
     parser.consume('is')
-    
+
     return {
       type: 'JsdocTypePredicate',
       left,
@@ -161,7 +161,7 @@ export const predicateParslet = composeParslet({
 10. Add parslet to grammar. Now we need to tell the parser that we actually want to use this parslet. For this we add
     the parslet to the `typescriptGrammar` array in `src/grammars/typescriptGrammar.ts`.
 
-11. Run tests and debug until done. In the end we see that all tests pass, and we are done. We can now add some more tests 
+11. Run tests and debug until done. In the end we see that all tests pass, and we are done. We can now add some more tests
     if we like.
 
 12. If there are any problems with this guide, feel free to open an issue!

--- a/src/assertTypes.ts
+++ b/src/assertTypes.ts
@@ -1,6 +1,6 @@
 import { type IndexSignatureResult, type KeyValueResult, type MappedTypeResult } from './result/NonRootResult'
 import { UnexpectedTypeError } from './errors'
-import { type NameResult, type NumberResult, type RootResult, type VariadicResult } from './result/RootResult'
+import { type NameResult, type NumberResult, type RootResult, type VariadicResult, type TupleResult, type GenericResult } from './result/RootResult'
 import { type IntermediateResult } from './result/IntermediateResult'
 
 /**
@@ -53,6 +53,18 @@ export function assertNumberOrVariadicNameResult (result: IntermediateResult): N
     throw new UnexpectedTypeError(result)
   }
   return result
+}
+
+export function assertArrayOrTupleResult (result: IntermediateResult): TupleResult | GenericResult {
+  if (result.type === 'JsdocTypeTuple') {
+    return result
+  }
+
+  if (result.type === 'JsdocTypeGeneric' && result.meta.brackets === 'square') {
+    return result
+  }
+
+  throw new UnexpectedTypeError(result)
 }
 
 export function isSquaredProperty (result: IntermediateResult): result is IndexSignatureResult | MappedTypeResult {

--- a/src/grammars/typescriptGrammar.ts
+++ b/src/grammars/typescriptGrammar.ts
@@ -24,6 +24,7 @@ import { predicateParslet } from '../parslets/predicateParslet'
 import { createObjectFieldParslet } from '../parslets/ObjectFieldParslet'
 import { createKeyValueParslet } from '../parslets/KeyValueParslet'
 import { objectSquaredPropertyParslet } from '../parslets/ObjectSquaredPropertyParslet'
+import { readonlyArrayParslet } from '../parslets/ReadonlyArrayParslet'
 
 const objectFieldGrammar: Grammar = [
   readonlyPropertyParslet,
@@ -49,6 +50,7 @@ export const typescriptGrammar: Grammar = [
     allowKeyTypes: false,
     objectFieldGrammar
   }),
+  readonlyArrayParslet,
   typeOfParslet,
   keyOfParslet,
   importParslet,

--- a/src/parslets/ReadonlyArrayParslet.ts
+++ b/src/parslets/ReadonlyArrayParslet.ts
@@ -1,0 +1,15 @@
+import { composeParslet } from './Parslet'
+import { Precedence } from '../Precedence'
+import { assertArrayOrTupleResult } from '../assertTypes'
+
+export const readonlyArrayParslet = composeParslet({
+  name: 'readonlyArrayParslet',
+  accept: type => type === 'readonly',
+  parsePrefix: parser => {
+    parser.consume('readonly')
+    return {
+      type: 'JsdocTypeReadonlyArray',
+      element: assertArrayOrTupleResult(parser.parseIntermediateType(Precedence.ALL))
+    }
+  }
+})

--- a/src/parslets/TypeOfParslet.ts
+++ b/src/parslets/TypeOfParslet.ts
@@ -1,6 +1,5 @@
 import { composeParslet } from './Parslet'
 import { Precedence } from '../Precedence'
-import { assertRootResult } from '../assertTypes'
 
 export const typeOfParslet = composeParslet({
   name: 'typeOfParslet',
@@ -9,7 +8,7 @@ export const typeOfParslet = composeParslet({
     parser.consume('typeof')
     return {
       type: 'JsdocTypeTypeof',
-      element: assertRootResult(parser.parseType(Precedence.KEY_OF_TYPE_OF))
+      element: parser.parseType(Precedence.KEY_OF_TYPE_OF)
     }
   }
 })

--- a/src/result/RootResult.ts
+++ b/src/result/RootResult.ts
@@ -35,6 +35,7 @@ export type RootResult =
   | NumberResult
   | PredicateResult
   | AssertsResult
+  | ReadonlyArrayResult
 
 export type QuoteStyle = 'single' | 'double'
 
@@ -292,4 +293,12 @@ export interface AssertsResult {
   type: 'JsdocTypeAsserts'
   left: NameResult
   right: RootResult
+}
+
+/**
+ * A TypeScript readonly modifier. Is used like this: `readonly string[]`.
+ */
+export interface ReadonlyArrayResult {
+  type: 'JsdocTypeReadonlyArray'
+  element: RootResult
 }

--- a/src/transforms/catharsisTransform.ts
+++ b/src/transforms/catharsisTransform.ts
@@ -316,7 +316,8 @@ const catharsisTransformRules: TransformRules<CatharsisParseResult> = {
   JsdocTypeIntersection: notAvailableTransform,
   JsdocTypeProperty: notAvailableTransform,
   JsdocTypePredicate: notAvailableTransform,
-  JsdocTypeAsserts: notAvailableTransform
+  JsdocTypeAsserts: notAvailableTransform,
+  JsdocTypeReadonlyArray: notAvailableTransform
 }
 
 export function catharsisTransform (result: RootResult): CatharsisParseResult {

--- a/src/transforms/identityTransformRules.ts
+++ b/src/transforms/identityTransformRules.ts
@@ -198,6 +198,11 @@ export function identityTransformRules (): TransformRules<NonRootResult> {
       type: 'JsdocTypeAsserts',
       left: transform(result.left) as NameResult,
       right: transform(result.right) as RootResult
+    }),
+
+    JsdocTypeReadonlyArray: (result, transform) => ({
+      type: 'JsdocTypeReadonlyArray',
+      element: transform(result.element) as RootResult
     })
   }
 }

--- a/src/transforms/jtpTransform.ts
+++ b/src/transforms/jtpTransform.ts
@@ -525,7 +525,9 @@ const jtpRules: TransformRules<JtpResult> = {
 
   JsdocTypeIndexSignature: notAvailableTransform,
 
-  JsdocTypeAsserts: notAvailableTransform
+  JsdocTypeAsserts: notAvailableTransform,
+
+  JsdocTypeReadonlyArray: notAvailableTransform
 }
 
 export function jtpTransform (result: RootResult): JtpResult {

--- a/src/transforms/stringify.ts
+++ b/src/transforms/stringify.ts
@@ -165,7 +165,9 @@ export function stringifyRules (): TransformRules<string> {
 
     JsdocTypeMappedType: (result, transform) => `[${result.key} in ${transform(result.right)}]`,
 
-    JsdocTypeAsserts: (result, transform) => `asserts ${transform(result.left)} is ${transform(result.right)}`
+    JsdocTypeAsserts: (result, transform) => `asserts ${transform(result.left)} is ${transform(result.right)}`,
+
+    JsdocTypeReadonlyArray: (result, transform) => `readonly ${transform(result.element)}`
   }
 }
 

--- a/src/visitorKeys.ts
+++ b/src/visitorKeys.ts
@@ -36,5 +36,6 @@ export const visitorKeys: VisitorKeys = {
   JsdocTypeVariadic: ['element'],
   JsdocTypeProperty: [],
   JsdocTypePredicate: ['left', 'right'],
-  JsdocTypeAsserts: ['left', 'right']
+  JsdocTypeAsserts: ['left', 'right'],
+  JsdocTypeReadonlyArray: ['element']
 }

--- a/test/fixtures/typescript/readonlyArray.spec.ts
+++ b/test/fixtures/typescript/readonlyArray.spec.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai'
+import { testFixture } from '../Fixture'
+import { parse } from '../../../src/parse'
+
+describe('typescript readonly arrays and tuples', () => {
+  describe('should parse a readonly array', () => {
+    testFixture({
+      input: 'readonly string[]',
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeReadonlyArray',
+        element: {
+          type: 'JsdocTypeGeneric',
+          left: {
+            type: 'JsdocTypeName',
+            value: 'Array'
+          },
+          elements: [
+            {
+              type: 'JsdocTypeName',
+              value: 'string'
+            }
+          ],
+          meta: {
+            brackets: 'square',
+            dot: false
+          }
+        }
+      }
+    })
+  })
+
+  describe('should parse a readonly tuple', () => {
+    testFixture({
+      input: 'readonly [string, number]',
+      modes: ['typescript'],
+      expected: {
+        type: 'JsdocTypeReadonlyArray',
+        element: {
+          type: 'JsdocTypeTuple',
+          elements: [
+            {
+              type: 'JsdocTypeName',
+              value: 'string'
+            },
+            {
+              type: 'JsdocTypeName',
+              value: 'number'
+            }
+          ]
+        }
+      }
+    })
+  })
+
+  describe('should throw with bad type', () => {
+    it('does not allow a plain string type', () => {
+      expect(() => {
+        parse('readonly string', 'typescript')
+      }).to.throw('Unexpected type: \'JsdocTypeName\'.')
+    })
+
+    it('does not allow a generic Array', () => {
+      expect(() => {
+        parse('readonly Array<string>', 'typescript')
+      }).to.throw('Unexpected type: \'JsdocTypeGeneric\'.')
+    })
+  })
+})


### PR DESCRIPTION
Partial fix for #164 .

Also removes redundant check in `src/parslets/TypeOfParslet.ts`.

I found your `DEVELOPMENT.md` helpful. I was just not sure on which `PRECEDENCE` to use with `parseIntermediateType` in `src/parslets/ReadonlyArrayParslet.ts` so I went with `ALL`.