### PR TITLE
fix: avoid adding linebreaks to linebreak separator when not > 1 item

### DIFF
--- a/src/transforms/stringify.ts
+++ b/src/transforms/stringify.ts
@@ -142,13 +142,13 @@ export function stringifyRules (): TransformRules<string> {
     JsdocTypeNumber: result => result.value.toString(),
 
     JsdocTypeObject: (result, transform) => `{${
-      (result.meta.separator === 'linebreak'
+      (result.meta.separator === 'linebreak' && result.elements.length > 1
        ? '\n' + (result.meta.propertyIndent ?? '')
        : '') +
       result.elements.map(transform).join(
         (result.meta.separator === 'comma' ? ', ' : result.meta.separator === 'linebreak' ? '\n' + (result.meta.propertyIndent ?? '') : '; ')
       ) +
-      (result.meta.separator === 'linebreak'
+      (result.meta.separator === 'linebreak' && result.elements.length > 1
        ? '\n'
        : '')
     }}`,

--- a/test/fixtures/typescript/objects.spec.ts
+++ b/test/fixtures/typescript/objects.spec.ts
@@ -345,7 +345,8 @@ describe('typescript objects tests', () => {
       expected: {
         type: 'JsdocTypeObject',
         meta: {
-          separator: 'linebreak'
+          separator: 'linebreak',
+          propertyIndent: '  '
         },
         elements: [
           {
@@ -377,7 +378,8 @@ describe('typescript objects tests', () => {
       expected: {
         type: 'JsdocTypeObject',
         meta: {
-          separator: 'linebreak'
+          separator: 'linebreak',
+          propertyIndent: '  '
         },
         elements: [
           {


### PR DESCRIPTION
fix: avoid adding linebreaks to linebreak separator when not > 1 item

Also:
- test: add missing `propertyIndent`