### PR TITLE
feat: `parseNamePath` and `parseName`; add `parse` options (`strictMode`, `module`, `asyncFunctionBody`)

### DIFF
--- a/src/grammars/closureGrammar.ts
+++ b/src/grammars/closureGrammar.ts
@@ -1,5 +1,5 @@
 import { baseGrammar } from './baseGrammar.js'
-import { pathGrammar } from './pathGrammar.js'
+import { createPathGrammars } from './pathGrammar.js'
 import { createNameParslet } from '../parslets/NameParslet.js'
 import { nullableParslet } from '../parslets/NullableParslets.js'
 import type { Grammar } from './Grammar.js'
@@ -16,58 +16,131 @@ import { createNamePathParslet } from '../parslets/NamePathParslet.js'
 import { symbolParslet } from '../parslets/SymbolParslet.js'
 import { createObjectFieldParslet } from '../parslets/ObjectFieldParslet.js'
 
-const objectFieldGrammar: Grammar = [
-  createNameParslet({
-    allowedAdditionalTokens: ['typeof', 'module', 'keyof', 'event', 'external', 'in']
-  }),
-  nullableParslet,
-  optionalParslet,
-  stringValueParslet,
-  numberParslet,
-  createObjectFieldParslet({
-    allowSquaredProperties: false,
-    allowKeyTypes: false,
-    allowOptional: false,
-    allowReadonly: false
+export const createClosureGrammars = ({
+  module,
+  strictMode,
+  asyncFunctionBody,
+}: {
+  module: boolean,
+  strictMode: boolean,
+  asyncFunctionBody: boolean,
+}): {
+  closureNameGrammar: Grammar,
+  closureNamePathGrammar: Grammar,
+  closureGrammar: Grammar
+} => {
+  const { pathGrammar } = createPathGrammars({
+    module,
+    strictMode,
+    asyncFunctionBody,
   })
-]
 
-export const closureGrammar = [
-  ...baseGrammar,
-  createObjectParslet({
-    allowKeyTypes: false,
-    objectFieldGrammar
-  }),
-  createNameParslet({
-    allowedAdditionalTokens: ['event', 'external', 'in']
-  }),
-  typeOfParslet,
-  createFunctionParslet({
-    allowWithoutParenthesis: false,
-    allowNamedParameters: ['this', 'new'],
-    allowNoReturnType: true,
-    allowNewAsFunctionKeyword: false
-  }),
-  createVariadicParslet({
-    allowEnclosingBrackets: false,
-    allowPostfix: false
-  }),
-  // additional name parslet is needed for some special cases
-  createNameParslet({
-    allowedAdditionalTokens: ['keyof']
-  }),
-  createSpecialNamePathParslet({
-    allowedTypes: ['module'],
-    pathGrammar
-  }),
-  createNamePathParslet({
+  const objectFieldGrammar: Grammar = [
+    createNameParslet({
+      module,
+      strictMode,
+      asyncFunctionBody,
+      allowReservedWords: true,
+      allowedAdditionalTokens: [
+        'typeof', 'in',
+        'module', 'keyof', 'event', 'external'
+      ]
+    }),
+    nullableParslet,
+    optionalParslet,
+    stringValueParslet,
+    numberParslet,
+    createObjectFieldParslet({
+      allowSquaredProperties: false,
+      allowKeyTypes: false,
+      allowOptional: false,
+      allowReadonly: false
+    })
+  ]
+
+  const closureNamePathParslet = createNamePathParslet({
     allowSquareBracketsOnAnyType: false,
     allowJsdocNamePaths: true,
     pathGrammar
-  }),
-  createKeyValueParslet({
-    allowOptional: false,
-    allowVariadic: false
-  }),
-  symbolParslet
-]
+  })
+
+  const closureNameGrammar = [
+    createNameParslet({
+      module,
+      strictMode,
+      asyncFunctionBody,
+      allowReservedWords: false,
+      allowedAdditionalTokens: [
+        // Cannot be JavaScript reserved word like `typeof`
+        'module', 'keyof', 'event', 'external',
+        'readonly', 'is'
+      ]
+    })
+  ]
+
+  const closureNamePathGrammar = [
+    createNameParslet({
+      module,
+      strictMode,
+      asyncFunctionBody,
+      allowReservedWords: false,
+      allowedAdditionalTokens: [
+        'module', 'keyof', 'event', 'external',
+        'readonly', 'is',
+        'typeof', 'in'
+      ]
+    }),
+    closureNamePathParslet
+  ]
+
+  const typeNameParslet = createNameParslet({
+    module,
+    strictMode,
+    asyncFunctionBody,
+    // Todo: Should be disallowed except when used within types
+    allowReservedWords: true,
+    allowedAdditionalTokens: ['event', 'external']
+  })
+
+  const closureGrammar = [
+    ...baseGrammar,
+    createObjectParslet({
+      allowKeyTypes: false,
+      objectFieldGrammar
+    }),
+    typeNameParslet,
+    typeOfParslet,
+    createFunctionParslet({
+      allowWithoutParenthesis: false,
+      allowNamedParameters: ['this', 'new'],
+      allowNoReturnType: true,
+      allowNewAsFunctionKeyword: false
+    }),
+    createVariadicParslet({
+      allowEnclosingBrackets: false,
+      allowPostfix: false
+    }),
+    // additional name parslet is needed for some special cases
+    createNameParslet({
+      module,
+      strictMode,
+      asyncFunctionBody,
+      allowReservedWords: false,
+      allowedAdditionalTokens: ['keyof']
+    }),
+    createSpecialNamePathParslet({
+      allowedTypes: ['module'],
+      pathGrammar
+    }),
+    closureNamePathParslet,
+    createKeyValueParslet({
+      allowOptional: false,
+      allowVariadic: false
+    }),
+    symbolParslet
+  ]
+
+  return {
+    closureNameGrammar, closureNamePathGrammar, closureGrammar
+  }
+}

--- a/src/grammars/jsdocGrammar.ts
+++ b/src/grammars/jsdocGrammar.ts
@@ -1,6 +1,7 @@
 import { baseGrammar } from './baseGrammar.js'
 import type { Grammar } from './Grammar.js'
-import { pathGrammar } from './pathGrammar.js'
+import { createPathGrammars } from './pathGrammar.js'
+import type { TokenType } from '../lexer/Token.js'
 import { createFunctionParslet } from '../parslets/FunctionParslet.js'
 import { stringValueParslet } from '../parslets/StringValueParslet.js'
 import { createSpecialNamePathParslet } from '../parslets/SpecialNamePathParslet.js'
@@ -13,56 +14,128 @@ import { createObjectParslet } from '../parslets/ObjectParslet.js'
 import { createObjectFieldParslet } from '../parslets/ObjectFieldParslet.js'
 import { createKeyValueParslet } from '../parslets/KeyValueParslet.js'
 
-const jsdocBaseGrammar = [
-  ...baseGrammar,
-  createFunctionParslet({
-    allowWithoutParenthesis: true,
-    allowNamedParameters: ['this', 'new'],
-    allowNoReturnType: true,
-    allowNewAsFunctionKeyword: false
-  }),
-  stringValueParslet,
-  createSpecialNamePathParslet({
-    allowedTypes: ['module', 'external', 'event'],
-    pathGrammar
-  }),
-  createVariadicParslet({
-    allowEnclosingBrackets: true,
-    allowPostfix: true
-  }),
-  createNameParslet({
-    allowedAdditionalTokens: ['keyof']
-  }),
-  symbolParslet,
-  arrayBracketsParslet,
-  createNamePathParslet({
+export const createJsdocGrammars = ({
+  module,
+  strictMode,
+  asyncFunctionBody,
+}: {
+  module: boolean,
+  strictMode: boolean,
+  asyncFunctionBody: boolean,
+}): {
+  jsdocNameGrammar: Grammar,
+  jsdocNamePathGrammar: Grammar,
+  jsdocGrammar: Grammar
+} => {
+  const { pathGrammar } = createPathGrammars({
+    module,
+    strictMode,
+    asyncFunctionBody,
+  })
+
+
+  const jsdocNamePathParslet = createNamePathParslet({
     allowSquareBracketsOnAnyType: false,
     allowJsdocNamePaths: true,
     pathGrammar
   })
-]
 
-export const jsdocGrammar: Grammar = [
-  ...jsdocBaseGrammar,
-  createObjectParslet({
-    // jsdoc syntax allows full types as keys, so we need to pull in the full grammar here
-    // we leave out the object type deliberately
-    objectFieldGrammar: [
-      createNameParslet({
-        allowedAdditionalTokens: ['typeof', 'module', 'in']
-      }),
-      createObjectFieldParslet({
-        allowSquaredProperties: false,
-        allowKeyTypes: true,
-        allowOptional: false,
-        allowReadonly: false
-      }),
-      ...jsdocBaseGrammar
-    ],
-    allowKeyTypes: true
-  }),
-  createKeyValueParslet({
-    allowOptional: true,
-    allowVariadic: true
+  const baseNameTokens: TokenType[] = [
+    // Cannot be JavaScript reserved word like `typeof`
+    'module', 'keyof', 'event', 'external',
+    'readonly', 'is'
+  ]
+
+  const jsdocNameGrammar = [
+    createNameParslet({
+      module,
+      strictMode,
+      asyncFunctionBody,
+      allowReservedWords: false,
+      allowedAdditionalTokens: baseNameTokens
+    })
+  ]
+
+  const jsdocNamePathGrammar = [
+    createNameParslet({
+      module,
+      strictMode,
+      asyncFunctionBody,
+      allowReservedWords: false,
+      allowedAdditionalTokens: [
+        ...baseNameTokens,
+        // These should really only be allowed as properties
+        'typeof', 'in'
+      ]
+    }),
+    jsdocNamePathParslet
+  ]
+
+  const typeNameParslet = createNameParslet({
+    module,
+    strictMode,
+    asyncFunctionBody,
+    // Todo: Should be disallowed except when used within types
+    allowReservedWords: true,
+    allowedAdditionalTokens: ['keyof']
   })
-]
+
+  const jsdocBaseGrammar = [
+    ...baseGrammar,
+    createFunctionParslet({
+      allowWithoutParenthesis: true,
+      allowNamedParameters: ['this', 'new'],
+      allowNoReturnType: true,
+      allowNewAsFunctionKeyword: false
+    }),
+    stringValueParslet,
+    createSpecialNamePathParslet({
+      allowedTypes: ['module', 'external', 'event'],
+      pathGrammar
+    }),
+    createVariadicParslet({
+      allowEnclosingBrackets: true,
+      allowPostfix: true
+    }),
+    typeNameParslet,
+    symbolParslet,
+    arrayBracketsParslet,
+    jsdocNamePathParslet
+  ]
+
+  const jsdocGrammar: Grammar = [
+    ...jsdocBaseGrammar,
+    createObjectParslet({
+      // jsdoc syntax allows full types as keys, so we need to pull in the full grammar here
+      // we leave out the object type deliberately
+      objectFieldGrammar: [
+        createNameParslet({
+          module,
+          strictMode,
+          asyncFunctionBody,
+          allowReservedWords: true,
+          allowedAdditionalTokens: [
+            'typeof', 'in',
+            'module'
+          ]
+        }),
+        createObjectFieldParslet({
+          allowSquaredProperties: false,
+          allowKeyTypes: true,
+          allowOptional: false,
+          allowReadonly: false
+        }),
+        ...jsdocBaseGrammar
+      ],
+      allowKeyTypes: true
+    }),
+    createKeyValueParslet({
+      allowOptional: true,
+      allowVariadic: true
+    })
+  ]
+
+  return {
+    jsdocNameGrammar, jsdocNamePathGrammar, jsdocGrammar
+  }
+}

--- a/src/grammars/pathGrammar.ts
+++ b/src/grammars/pathGrammar.ts
@@ -5,23 +5,41 @@ import { stringValueParslet } from '../parslets/StringValueParslet.js'
 import { numberParslet } from '../parslets/NumberParslet.js'
 import { createSpecialNamePathParslet } from '../parslets/SpecialNamePathParslet.js'
 
-const basePathGrammar: Grammar = [
-  createNameParslet({
-    allowedAdditionalTokens: ['external', 'module']
-  }),
-  stringValueParslet,
-  numberParslet,
-  createNamePathParslet({
-    allowSquareBracketsOnAnyType: false,
-    allowJsdocNamePaths: true,
-    pathGrammar: null
-  })
-]
+export const createPathGrammars = ({
+  module, strictMode, asyncFunctionBody
+}: {
+  module: boolean,
+  strictMode: boolean,
+  asyncFunctionBody: boolean
+}): {
+  basePathGrammar: Grammar,
+  pathGrammar: Grammar
+} => {
+  const basePathGrammar: Grammar = [
+    createNameParslet({
+      module, strictMode, asyncFunctionBody,
+      allowReservedWords: false,
+      allowedAdditionalTokens: ['external', 'module']
+    }),
+    stringValueParslet,
+    numberParslet,
+    createNamePathParslet({
+      allowSquareBracketsOnAnyType: false,
+      allowJsdocNamePaths: true,
+      pathGrammar: null
+    })
+  ]
 
-export const pathGrammar: Grammar = [
-  ...basePathGrammar,
-  createSpecialNamePathParslet({
-    allowedTypes: ['event'],
-    pathGrammar: basePathGrammar
-  })
-]
+  const pathGrammar: Grammar = [
+    ...basePathGrammar,
+    createSpecialNamePathParslet({
+      allowedTypes: ['event'],
+      pathGrammar: basePathGrammar
+    })
+  ]
+
+  return {
+    basePathGrammar,
+    pathGrammar
+  }
+}

--- a/src/grammars/typescriptGrammar.ts
+++ b/src/grammars/typescriptGrammar.ts
@@ -1,7 +1,7 @@
 import { assertsParslet } from '../parslets/assertsParslet.js'
 import { baseGrammar } from './baseGrammar.js'
 import type { Grammar } from './Grammar.js'
-import { pathGrammar } from './pathGrammar.js'
+import { createPathGrammars } from './pathGrammar.js'
 import { createNameParslet } from '../parslets/NameParslet.js'
 import { nullableParslet } from '../parslets/NullableParslets.js'
 import { optionalParslet } from '../parslets/OptionalParslet.js'
@@ -30,79 +30,150 @@ import { readonlyArrayParslet } from '../parslets/ReadonlyArrayParslet.js'
 import { conditionalParslet } from '../parslets/ConditionalParslet.js'
 import { templateLiteralParslet } from '../parslets/TemplateLiteralParslet.js'
 
-const objectFieldGrammar: Grammar = [
-  functionPropertyParslet,
-  readonlyPropertyParslet,
-  createNameParslet({
-    allowedAdditionalTokens: ['typeof', 'module', 'keyof', 'event', 'external', 'in']
-  }),
-  nullableParslet,
-  optionalParslet,
-  stringValueParslet,
-  numberParslet,
-  createObjectFieldParslet({
-    allowSquaredProperties: true,
-    allowKeyTypes: false,
-    allowOptional: true,
-    allowReadonly: true
-  }),
-  objectSquaredPropertyParslet
-]
-
-export const typescriptGrammar: Grammar = [
-  ...baseGrammar,
-  createObjectParslet({
-    allowKeyTypes: false,
-    objectFieldGrammar,
-    signatureGrammar: [
-      createKeyValueParslet({
-        allowVariadic: true,
-        allowOptional: true,
-        acceptParameterList: true,
-      })
-    ]
-  }),
-  readonlyArrayParslet,
-  typeOfParslet,
-  keyOfParslet,
-  importParslet,
-  stringValueParslet,
-  createFunctionParslet({
-    allowWithoutParenthesis: true,
-    allowNoReturnType: true,
-    allowNamedParameters: ['this', 'new', 'args'],
-    allowNewAsFunctionKeyword: true
-  }),
-  createTupleParslet({
-    allowQuestionMark: false
-  }),
-  createVariadicParslet({
-    allowEnclosingBrackets: false,
-    allowPostfix: false
-  }),
-  assertsParslet,
-  conditionalParslet,
-  createNameParslet({
-    allowedAdditionalTokens: ['event', 'external', 'in']
-  }),
-  createSpecialNamePathParslet({
-    allowedTypes: ['module'],
-    pathGrammar
-  }),
-  arrayBracketsParslet,
-  arrowFunctionParslet,
-  genericArrowFunctionParslet,
-  createNamePathParslet({
-    allowSquareBracketsOnAnyType: true,
-    allowJsdocNamePaths: false,
-    pathGrammar
-  }),
-  intersectionParslet,
-  predicateParslet,
-  templateLiteralParslet,
-  createKeyValueParslet({
-    allowVariadic: true,
-    allowOptional: true
+export const createTypescriptGrammars = ({
+  module,
+  strictMode,
+  asyncFunctionBody,
+}: {
+  module: boolean,
+  strictMode: boolean,
+  asyncFunctionBody: boolean,
+}): {
+  typescriptNameGrammar: Grammar,
+  typescriptNamePathGrammar: Grammar,
+  typescriptGrammar: Grammar
+} => {
+  const { pathGrammar } = createPathGrammars({
+    module,
+    strictMode,
+    asyncFunctionBody,
   })
-]
 
+  const objectFieldGrammar: Grammar = [
+    functionPropertyParslet,
+    readonlyPropertyParslet,
+    createNameParslet({
+      module,
+      strictMode,
+      asyncFunctionBody,
+      allowReservedWords: true,
+      allowedAdditionalTokens: [
+        'typeof', 'in',
+        'module', 'keyof', 'event', 'external'
+      ]
+    }),
+    nullableParslet,
+    optionalParslet,
+    stringValueParslet,
+    numberParslet,
+    createObjectFieldParslet({
+      allowSquaredProperties: true,
+      allowKeyTypes: false,
+      allowOptional: true,
+      allowReadonly: true
+    }),
+    objectSquaredPropertyParslet
+  ]
+
+  const typescriptNameGrammar = [
+    createNameParslet({
+      module,
+      strictMode,
+      asyncFunctionBody,
+      allowReservedWords: false,
+      allowedAdditionalTokens: [
+        // Cannot be JavaScript reserved word like `typeof`
+        'module', 'keyof', 'event', 'external',
+        'readonly', 'is'
+      ]
+    })
+  ]
+
+  const typescriptNamePathGrammar = [
+    createNameParslet({
+      module,
+      strictMode,
+      asyncFunctionBody,
+      allowReservedWords: false,
+      allowedAdditionalTokens: [
+        'typeof', 'in',
+        'module', 'keyof', 'event', 'external',
+        'readonly', 'is'
+      ]
+    }),
+    createNamePathParslet({
+      allowSquareBracketsOnAnyType: true,
+      // Here we actually want JSDoc name paths (even though TS
+      //   in JSDoc namepath positions interpret them differently
+      //   than JSDoc)
+      allowJsdocNamePaths: true,
+      pathGrammar
+    })
+  ]
+
+  const typescriptGrammar: Grammar = [
+    ...baseGrammar,
+    createObjectParslet({
+      allowKeyTypes: false,
+      objectFieldGrammar,
+      signatureGrammar: [
+        createKeyValueParslet({
+          allowVariadic: true,
+          allowOptional: true,
+          acceptParameterList: true,
+        })
+      ]
+    }),
+    readonlyArrayParslet,
+    typeOfParslet,
+    keyOfParslet,
+    importParslet,
+    stringValueParslet,
+    createFunctionParslet({
+      allowWithoutParenthesis: true,
+      allowNoReturnType: true,
+      allowNamedParameters: ['this', 'new', 'args'],
+      allowNewAsFunctionKeyword: true
+    }),
+    createTupleParslet({
+      allowQuestionMark: false
+    }),
+    createVariadicParslet({
+      allowEnclosingBrackets: false,
+      allowPostfix: false
+    }),
+    assertsParslet,
+    conditionalParslet,
+    createNameParslet({
+      module,
+      strictMode,
+      asyncFunctionBody,
+      // Todo: Should be disallowed except when used within types
+      allowReservedWords: true,
+      allowedAdditionalTokens: ['event', 'external']
+    }),
+    createSpecialNamePathParslet({
+      allowedTypes: ['module'],
+      pathGrammar
+    }),
+    arrayBracketsParslet,
+    arrowFunctionParslet,
+    genericArrowFunctionParslet,
+    createNamePathParslet({
+      allowSquareBracketsOnAnyType: true,
+      allowJsdocNamePaths: false,
+      pathGrammar
+    }),
+    intersectionParslet,
+    predicateParslet,
+    templateLiteralParslet,
+    createKeyValueParslet({
+      allowVariadic: true,
+      allowOptional: true
+    })
+  ]
+
+  return {
+    typescriptNameGrammar, typescriptNamePathGrammar, typescriptGrammar
+  }
+}

--- a/src/lexer/Token.ts
+++ b/src/lexer/Token.ts
@@ -51,3 +51,82 @@ export interface Token {
   text: string
   startOfLine: boolean
 }
+
+// May not be needed
+export const reservedWordsAsTypes = [
+  'extends',
+  'false',
+  'import',
+  'in',
+  'new',
+  'null',
+  'this',
+  'true',
+  'typeof',
+  'void'
+]
+
+export const reservedWords = {
+  always: [
+    'break',
+    'case',
+    'catch',
+    'class',
+    'const',
+    'continue',
+    'debugger',
+    'default',
+    'delete',
+    'do',
+    'else',
+    'export',
+    'extends',
+    'false',
+    'finally',
+    'for',
+    'function',
+    'if',
+    'import',
+    'in',
+    'instanceof',
+    'new',
+    'null',
+    'return',
+    'super',
+    'switch',
+    'this',
+    'throw',
+    'true',
+    'try',
+    'typeof',
+    'var',
+    'void',
+    'while',
+    'with'
+  ],
+  strictMode: [
+    'let',
+    'static',
+    'yield'
+  ],
+  moduleOrAsyncFunctionBodies: [
+    'await'
+  ]
+}
+
+export const futureReservedWords = {
+  always: ['enum'],
+  strictMode: [
+    'implements',
+    'interface',
+    'package',
+    'private',
+    'protected',
+    'public'
+  ]
+}
+
+export const strictModeNonIdentifiers = [
+  'arguments',
+  'eval'
+];

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,7 +1,7 @@
 import { Parser } from './Parser.js'
-import { jsdocGrammar } from './grammars/jsdocGrammar.js'
-import { closureGrammar } from './grammars/closureGrammar.js'
-import { typescriptGrammar } from './grammars/typescriptGrammar.js'
+import { createJsdocGrammars } from './grammars/jsdocGrammar.js'
+import { createClosureGrammars } from './grammars/closureGrammar.js'
+import { createTypescriptGrammars } from './grammars/typescriptGrammar.js'
 import type { RootResult } from './result/RootResult.js'
 import { Lexer } from './lexer/Lexer.js'
 import { rules, looseRules } from './lexer/LexerRules.js'
@@ -15,8 +15,14 @@ export type ParseMode = 'closure' | 'jsdoc' | 'typescript'
  */
 export function parse (
   expression: string, mode: ParseMode, {
-    computedPropertyParser
+    computedPropertyParser,
+    module = true,
+    strictMode = false,
+    asyncFunctionBody = false
   }: {
+    module?: boolean,
+    strictMode?: boolean,
+    asyncFunctionBody?: boolean,
     computedPropertyParser?: (
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Actual API
       text: string, options?: any
@@ -24,11 +30,28 @@ export function parse (
   } = {}
 ): RootResult {
   switch (mode) {
-    case 'closure':
+    case 'closure': {
+      const { closureGrammar } = createClosureGrammars({
+        module,
+        strictMode,
+        asyncFunctionBody
+      });
       return (new Parser(closureGrammar, Lexer.create(looseRules, expression))).parse()
-    case 'jsdoc':
+    } case 'jsdoc': {
+      const { jsdocGrammar } = createJsdocGrammars({
+        module,
+        strictMode,
+        asyncFunctionBody
+      })
       return (new Parser(jsdocGrammar, Lexer.create(looseRules, expression))).parse()
-    case 'typescript':
+    } case 'typescript': {
+      const {
+        typescriptGrammar
+      } = createTypescriptGrammars({
+        module,
+        strictMode,
+        asyncFunctionBody
+      })
       return (new Parser(
         typescriptGrammar,
         Lexer.create(rules, expression),
@@ -39,6 +62,7 @@ export function parse (
           }
         }
       )).parse()
+    }
   }
 }
 
@@ -60,4 +84,100 @@ export function tryParse (expression: string, modes: ParseMode[] = ['typescript'
   }
   // eslint-disable-next-line @typescript-eslint/only-throw-error -- Ok
   throw error
+}
+
+/**
+ * This function parses the given expression in the given mode and produces a name path.
+ * @param expression
+ * @param mode
+ */
+export function parseNamePath (
+  expression: string, mode: ParseMode,
+  {
+    module = true,
+    strictMode = true,
+    asyncFunctionBody = true
+  }: {
+    module?: boolean,
+    strictMode?: boolean,
+    asyncFunctionBody?: boolean
+  } = {}
+): RootResult {
+  switch (mode) {
+    case 'closure': {
+      const { closureNamePathGrammar } = createClosureGrammars({
+        module,
+        strictMode,
+        asyncFunctionBody
+      });
+      return (new Parser(closureNamePathGrammar, Lexer.create(looseRules, expression))).parse()
+    } case 'jsdoc': {
+      const { jsdocNamePathGrammar } = createJsdocGrammars({
+        module,
+        strictMode,
+        asyncFunctionBody
+      })
+      return (new Parser(jsdocNamePathGrammar, Lexer.create(looseRules, expression))).parse()
+    } case 'typescript': {
+      const {
+        typescriptNamePathGrammar
+      } = createTypescriptGrammars({
+        module,
+        strictMode,
+        asyncFunctionBody
+      })
+      return (new Parser(
+        typescriptNamePathGrammar,
+        Lexer.create(rules, expression)
+      )).parse()
+    }
+  }
+}
+
+/**
+ * This function parses the given expression in the given mode and produces a name.
+ * @param expression
+ * @param mode
+ */
+export function parseName (
+  expression: string, mode: ParseMode,
+  {
+    module = true,
+    strictMode = true,
+    asyncFunctionBody = true
+  }: {
+    module?: boolean,
+    strictMode?: boolean,
+    asyncFunctionBody?: boolean
+  } = {}
+): RootResult {
+  switch (mode) {
+    case 'closure': {
+      const { closureNameGrammar } = createClosureGrammars({
+        module,
+        strictMode,
+        asyncFunctionBody
+      });
+      return (new Parser(closureNameGrammar, Lexer.create(looseRules, expression))).parse()
+    } case 'jsdoc': {
+      const { jsdocNameGrammar } = createJsdocGrammars({
+        module,
+        strictMode,
+        asyncFunctionBody
+      })
+      return (new Parser(jsdocNameGrammar, Lexer.create(looseRules, expression))).parse()
+    } case 'typescript': {
+      const {
+        typescriptNameGrammar
+      } = createTypescriptGrammars({
+        module,
+        strictMode,
+        asyncFunctionBody
+      })
+      return (new Parser(
+        typescriptNameGrammar,
+        Lexer.create(rules, expression)
+      )).parse()
+    }
+  }
 }

--- a/src/parslets/NameParslet.ts
+++ b/src/parslets/NameParslet.ts
@@ -1,14 +1,54 @@
-import type { TokenType } from '../lexer/Token.js'
+import {
+  reservedWords, futureReservedWords, strictModeNonIdentifiers,
+  type TokenType
+} from '../lexer/Token.js'
 import { composeParslet, type ParsletFunction } from './Parslet.js'
 
-export function createNameParslet ({ allowedAdditionalTokens }: {
+export function createNameParslet ({
+  allowedAdditionalTokens, allowReservedWords,
+  module, strictMode, asyncFunctionBody
+}: {
+  allowReservedWords: boolean,
   allowedAdditionalTokens: TokenType[]
+  module: boolean,
+  strictMode: boolean,
+  asyncFunctionBody: boolean,
 }): ParsletFunction {
   return composeParslet({
     name: 'nameParslet',
     accept: type => type === 'Identifier' || type === 'this' || type === 'new' || allowedAdditionalTokens.includes(type),
     parsePrefix: parser => {
       const { type, text } = parser.lexer.current
+
+      if (!allowReservedWords) {
+        if (reservedWords.always.includes(text)) {
+          throw new Error(`Unexpected reserved keyword "${text}"`)
+        }
+        if (futureReservedWords.always.includes(text)) {
+          throw new Error(`Unexpected future reserved keyword "${text}"`)
+        }
+        if ((module !== undefined && module) ||
+          (strictMode !== undefined && strictMode)
+        ) {
+          if (reservedWords.strictMode.includes(text)) {
+            throw new Error(`Unexpected reserved keyword "${text}" for strict mode`)
+          }
+          if (futureReservedWords.strictMode.includes(text)) {
+            throw new Error(`Unexpected future reserved keyword "${text}" for strict mode`)
+          }
+          if (strictModeNonIdentifiers.includes(text)) {
+            throw new Error(`The item "${text}" is not an identifier in strict mode`);
+          }
+        }
+        if ((module !== undefined && module) ||
+          (asyncFunctionBody !== undefined && asyncFunctionBody)
+        ) {
+          if (reservedWords.moduleOrAsyncFunctionBodies.includes(text)) {
+            throw new Error(`Unexpected reserved keyword "${text}" for modules or async function bodies`)
+          }
+        }
+      }
+
       parser.consume(type)
 
       return {

--- a/src/parslets/ObjectParslet.ts
+++ b/src/parslets/ObjectParslet.ts
@@ -4,7 +4,6 @@ import { Precedence } from '../Precedence.js'
 import { UnexpectedTypeError } from '../errors.js'
 import type { ObjectResult } from '../result/RootResult.js'
 import type { Grammar } from '../grammars/Grammar.js'
-import { typescriptGrammar } from '../grammars/typescriptGrammar.js'
 import { getParameters } from './FunctionParslet.js'
 
 export function createObjectParslet ({ signatureGrammar, objectFieldGrammar, allowKeyTypes }: {
@@ -78,11 +77,10 @@ export function createObjectParslet ({ signatureGrammar, objectFieldGrammar, all
             field.type === 'JsdocTypeConstructorSignature' ||
             field.type === 'JsdocTypeMethodSignature')
           ) {
-
             const signatureParser = new Parser(
               [
                 ...signatureGrammar,
-                ...typescriptGrammar.flatMap((grammar) => {
+                ...parser.grammar.flatMap((grammar) => {
                   // We're supplying our own version
                   if (grammar.name === 'keyValueParslet') {
                     return []

--- a/src/parslets/ObjectSquaredPropertyParslet.ts
+++ b/src/parslets/ObjectSquaredPropertyParslet.ts
@@ -2,7 +2,6 @@ import { composeParslet } from './Parslet.js'
 import { Parser } from '../Parser.js'
 import type { ObjectFieldResult, ComputedPropertyResult, ComputedMethodResult } from '../result/NonRootResult.js'
 import { Precedence } from '../Precedence.js'
-import { typescriptGrammar } from '../grammars/typescriptGrammar.js'
 import { createKeyValueParslet } from '../parslets/KeyValueParslet.js'
 import type { RootResult } from '../result/RootResult.js'
 import { getParameters } from './FunctionParslet.js'
@@ -169,7 +168,7 @@ export const objectSquaredPropertyParslet = composeParslet({
               allowOptional: true,
               acceptParameterList: true,
             }),
-            ...typescriptGrammar.flatMap((grammar) => {
+            ...parser.baseParser.grammar.flatMap((grammar) => {
               // We're supplying our own version
               if (grammar.name === 'keyValueParslet') {
                 return []

--- a/src/parslets/TemplateLiteralParslet.ts
+++ b/src/parslets/TemplateLiteralParslet.ts
@@ -2,7 +2,6 @@ import { composeParslet } from './Parslet.js'
 import type { RootResult } from '../result/RootResult.js'
 import { Precedence } from '../Precedence.js'
 import { getTemplateLiteralLiteral } from '../lexer/LexerRules.js'
-import { typescriptGrammar } from '../grammars/typescriptGrammar.js'
 import { Parser } from '../Parser.js'
 import { Lexer } from '../lexer/Lexer.js'
 
@@ -45,7 +44,7 @@ export const templateLiteralParslet = composeParslet({
           //   so we avoid processing them (may be part of a literal)
           try {
             templateParser = new Parser(
-              typescriptGrammar,
+              parser.grammar,
               Lexer.create(parser.lexer.lexerRules, snipped)
             )
             interpolationType = templateParser.parseType(Precedence.ALL)

--- a/test/FunctionParslet.spec.ts
+++ b/test/FunctionParslet.spec.ts
@@ -1,9 +1,15 @@
 import { expect } from 'chai'
-import { jsdocGrammar } from '../src/grammars/jsdocGrammar.js'
+import { createJsdocGrammars } from '../src/grammars/jsdocGrammar.js'
 import { createFunctionParslet } from '../src/parslets/FunctionParslet.js'
 import { Parser } from '../src/Parser.js'
 import { Lexer } from '../src/lexer/Lexer.js'
 import { rules } from '../src/lexer/LexerRules.js'
+
+const { jsdocGrammar } = createJsdocGrammars({
+  module: true,
+  strictMode: true,
+  asyncFunctionBody: true
+})
 
 function parse (text: string, allowNoReturnType = true): void {
   // Replace other function parslet with one setting

--- a/test/ObjectParslet.spec.ts
+++ b/test/ObjectParslet.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { stub, type SinonStub } from 'sinon'
 
-import { jsdocGrammar } from '../src/grammars/jsdocGrammar.js'
+import { createJsdocGrammars } from '../src/grammars/jsdocGrammar.js'
 import { Parser } from '../src/Parser.js'
 import type { Grammar } from '../src/grammars/Grammar.js'
 
@@ -9,6 +9,12 @@ import { createObjectParslet } from '../src/parslets/ObjectParslet.js'
 import type { RootResult } from '../src/result/RootResult.js'
 import { Lexer } from '../src/lexer/Lexer.js'
 import { rules } from '../src/lexer/LexerRules.js'
+
+const { jsdocGrammar } = createJsdocGrammars({
+  module: true,
+  strictMode: true,
+  asyncFunctionBody: true
+})
 
 describe('`ObjectParslet`', () => {
   beforeEach(() => {

--- a/test/ObjectSquaredPropertyParslet.spec.ts
+++ b/test/ObjectSquaredPropertyParslet.spec.ts
@@ -27,6 +27,10 @@ describe('`ObjectSquaredPropertyParslet`', () => {
   it('throws without `:` or `in`', () => {
     const objectFieldGrammar: Grammar = [
       createNameParslet({
+        module: true,
+        strictMode: true,
+        asyncFunctionBody: true,
+        allowReservedWords: true,
         allowedAdditionalTokens: []
       }),
       objectSquaredPropertyParslet

--- a/test/ParameterListParslet.spec.ts
+++ b/test/ParameterListParslet.spec.ts
@@ -22,6 +22,10 @@ describe('ParameterListParslet', () => {
           allowTrailingComma: false
         }),
         createNameParslet({
+          module: true,
+          strictMode: true,
+          asyncFunctionBody: true,
+          allowReservedWords: false,
           allowedAdditionalTokens: []
         }),
         createObjectParslet({

--- a/test/Parser.spec.ts
+++ b/test/Parser.spec.ts
@@ -3,9 +3,17 @@ import { Parser } from '../src/Parser.js'
 
 import type { NoParsletFoundError, EarlyEndOfParseError } from '../src/errors.js'
 
-import { typescriptGrammar } from '../src/grammars/typescriptGrammar.js'
+import { createTypescriptGrammars } from '../src/grammars/typescriptGrammar.js'
 import { Lexer } from '../src/lexer/Lexer.js'
 import { rules } from '../src/lexer/LexerRules.js'
+
+const {
+  typescriptGrammar
+} = createTypescriptGrammars({
+  module: true,
+  strictMode: true,
+  asyncFunctionBody: true
+})
 
 describe('Parser', () => {
   it('should consume an array of tokens', () => {

--- a/test/SpecialTypesParslet.spec.ts
+++ b/test/SpecialTypesParslet.spec.ts
@@ -3,9 +3,17 @@ import { expect } from 'chai'
 import { specialTypesParslet } from '../src/parslets/SpecialTypesParslet.js'
 import { Parser } from '../src/Parser.js'
 import { Precedence } from '../src/Precedence.js'
-import { typescriptGrammar } from '../src/grammars/typescriptGrammar.js'
+import { createTypescriptGrammars } from '../src/grammars/typescriptGrammar.js'
 import { Lexer } from '../src/lexer/Lexer.js'
 import { rules } from '../src/lexer/LexerRules.js'
+
+const {
+  typescriptGrammar
+} = createTypescriptGrammars({
+  module: true,
+  strictMode: true,
+  asyncFunctionBody: true
+})
 
 class BadParser extends Parser {
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this -- Testing

--- a/test/api.errors.spec.ts
+++ b/test/api.errors.spec.ts
@@ -2,13 +2,19 @@ import { expect } from 'chai'
 
 import { getParameters } from '../src/parslets/FunctionParslet.js'
 import { createNamePathParslet } from '../src/parslets/NamePathParslet.js'
-import { pathGrammar } from '../src/grammars/pathGrammar.js'
+import { createPathGrammars } from '../src/grammars/pathGrammar.js'
 import { Parser } from '../src/Parser.js'
 import { createSpecialNamePathParslet } from '../src/parslets/SpecialNamePathParslet.js'
 import { createNameParslet } from '../src/parslets/NameParslet.js'
 import { specialTypesParslet } from '../src/parslets/SpecialTypesParslet.js'
 import { Lexer } from '../src/lexer/Lexer.js'
 import { rules } from '../src/lexer/LexerRules.js'
+
+const { pathGrammar } = createPathGrammars({
+  module: true,
+  strictMode: true,
+  asyncFunctionBody: true,
+})
 
 describe('API errors', () => {
   describe('`getParameters`', () => {
@@ -55,6 +61,10 @@ describe('API errors', () => {
             // These are all we need here
             namePathParslet,
             createNameParslet({
+              module: true,
+              strictMode: true,
+              asyncFunctionBody: true,
+              allowReservedWords: false,
               allowedAdditionalTokens: []
             })
           ],
@@ -88,6 +98,11 @@ describe('API errors', () => {
             // These are all we need here
             namePathParslet,
             createNameParslet({
+              module: true,
+              strictMode: true,
+              asyncFunctionBody: true,
+              // Todo: Should not be allowed at root here
+              allowReservedWords: true,
               allowedAdditionalTokens: []
             })
           ],

--- a/test/fixtures/Fixture.ts
+++ b/test/fixtures/Fixture.ts
@@ -6,7 +6,7 @@ import { parse as espree } from 'espree'
 import { generate } from '@es-joy/escodegen'
 import { jtpTransform } from '../../src/transforms/jtpTransform.js'
 import { simplify } from '../../src/transforms/simplify.js'
-import { catharsisTransform, parse, type RootResult, type ParseMode, stringify } from '../../src/index.js'
+import { catharsisTransform, parse, parseName, parseNamePath, type RootResult, type ParseMode, stringify } from '../../src/index.js'
 
 const { parse: catharsisParse } = catharsis
 
@@ -40,17 +40,32 @@ interface BaseFixture {
   stringified?: string
 }
 
+interface extraParseArgs {
+  module?: boolean,
+  strictMode?: boolean,
+  asyncFunctionBody?: boolean
+}
+
 type SuccessFixture = BaseFixture & {
   /**
    * The {@link ParseMode}s that the expression is expected to get parsed in. In all other modes it is expected to fail.
    */
-  modes: ParseMode[]
+  modes: ParseMode[],
+  parseName?: true,
+  extraParseArgs?: extraParseArgs
+  parseNamePath?: true
 }
 
 type ErrorFixture = BaseFixture & ({
-  error: string
+  error: string,
+  parseName?: true,
+  extraParseArgs?: extraParseArgs,
+  parseNamePath?: true
 } | {
-  errors: Partial<Record<ParseMode, string>>
+  errors: Partial<Record<ParseMode, string>>,
+  parseName?: true,
+  extraParseArgs?: extraParseArgs
+  parseNamePath?: true
 })
 
 export type Fixture = SuccessFixture | ErrorFixture
@@ -61,7 +76,11 @@ function testParser (mode: ParseMode, fixture: Fixture): RootResult | undefined 
   if ('modes' in fixture) {
     if (fixture.modes.includes(mode)) {
       it(`is parsed in '${mode}' mode`, () => {
-        const result = parse(
+        const result = fixture.parseNamePath ? parseNamePath(
+          fixture.input,
+          mode,
+          fixture.extraParseArgs
+        ) : fixture.parseName ? parseName(fixture.input, mode, fixture.extraParseArgs) : parse(
           fixture.input,
           mode,
           fixture.espree !== undefined && fixture.espree ? {
@@ -72,7 +91,11 @@ function testParser (mode: ParseMode, fixture: Fixture): RootResult | undefined 
         expect(result).to.deep.equal(expected)
       })
       try {
-        return parse(
+        return fixture.parseNamePath ? parseNamePath(
+          fixture.input,
+          mode,
+          fixture.extraParseArgs
+        ) : fixture.parseName ? parseName(fixture.input, mode, fixture.extraParseArgs) :parse(
           fixture.input,
           mode,
           fixture.espree !== undefined && fixture.espree ? {
@@ -87,7 +110,17 @@ function testParser (mode: ParseMode, fixture: Fixture): RootResult | undefined 
     } else {
       it(`fails to parse in '${mode}' mode`, () => {
         expect(() => {
-          parse(fixture.input, mode)
+          if (fixture.parseNamePath) {
+            parseNamePath(
+              fixture.input,
+              mode,
+              fixture.extraParseArgs
+            )
+          } else if (fixture.parseName) {
+            parseName(fixture.input, mode, fixture.extraParseArgs)
+          } else {
+            parse(fixture.input, mode)
+          }
         }).to.throw()
       })
     }
@@ -96,7 +129,17 @@ function testParser (mode: ParseMode, fixture: Fixture): RootResult | undefined 
     if (expectedErrorForMode !== undefined) {
       it(`In '${mode}' mode, throws with: ${expectedErrorForMode}`, () => {
         expect(() => {
-          parse(fixture.input, mode)
+          if (fixture.parseNamePath) {
+            parseNamePath(
+              fixture.input,
+              mode,
+              fixture.extraParseArgs
+            )
+          } else if (fixture.parseName) {
+            parseName(fixture.input, mode, fixture.extraParseArgs)
+          } else {
+            parse(fixture.input, mode)
+          }
         }).to.throw(expectedErrorForMode)
       })
     }

--- a/test/fixtures/typescript/parseName.spec.ts
+++ b/test/fixtures/typescript/parseName.spec.ts
@@ -1,0 +1,125 @@
+import { testFixture } from '../Fixture.js'
+
+describe('parses simple name', () => {
+  testFixture({
+    input: 'foo',
+    modes: ['jsdoc', 'closure', 'typescript'],
+    parseName: true,
+    expected: {
+      type: 'JsdocTypeName',
+      value: 'foo'
+    }
+  })
+});
+
+describe('errs with always reserved word', () => {
+  testFixture({
+    input: 'continue',
+    parseName: true,
+    extraParseArgs: {
+      module: false,
+      strictMode: false,
+      asyncFunctionBody: false
+    },
+    error: 'Unexpected reserved keyword "continue"'
+  })
+});
+
+describe('errs with future always reserved word', () => {
+  testFixture({
+    input: 'enum',
+    parseName: true,
+    extraParseArgs: {
+      module: false,
+      strictMode: false,
+      asyncFunctionBody: false
+    },
+    error: 'Unexpected future reserved keyword "enum"'
+  })
+});
+
+describe('errs with strict-mode-restricted (module) reserved word', () => {
+  testFixture({
+    input: 'let',
+    parseName: true,
+    extraParseArgs: {
+      module: true,
+      strictMode: false,
+      asyncFunctionBody: false
+    },
+    error: 'Unexpected reserved keyword "let" for strict mode'
+  })
+});
+
+describe('errs with strict-mode-restricted reserved word', () => {
+  testFixture({
+    input: 'let',
+    parseName: true,
+    extraParseArgs: {
+      module: false,
+      strictMode: true,
+      asyncFunctionBody: false
+    },
+    error: 'Unexpected reserved keyword "let" for strict mode'
+  })
+});
+
+describe('errs with future strict-mode-restricted reserved word', () => {
+  testFixture({
+    input: 'implements',
+    parseName: true,
+    extraParseArgs: {
+      module: true,
+      strictMode: false,
+      asyncFunctionBody: false
+    },
+    error: 'Unexpected future reserved keyword "implements" for strict mode'
+  })
+});
+
+describe('errs with non-identifier in strict mode', () => {
+  testFixture({
+    input: 'arguments',
+    parseName: true,
+    extraParseArgs: {
+      module: true,
+      strictMode: false,
+      asyncFunctionBody: false
+    },
+    error: 'The item "arguments" is not an identifier in strict mode'
+  })
+});
+
+describe('errs with (module) reserved word in module/async context', () => {
+  testFixture({
+    input: 'await',
+    parseName: true,
+    extraParseArgs: {
+      module: true,
+      strictMode: false,
+      asyncFunctionBody: false
+    },
+    error: 'Unexpected reserved keyword "await" for modules or async function bodies'
+  })
+});
+
+describe('errs with (asyncFunctionBody) reserved word in module/async context', () => {
+  testFixture({
+    input: 'await',
+    parseName: true,
+    extraParseArgs: {
+      module: false,
+      strictMode: false,
+      asyncFunctionBody: true
+    },
+    error: 'Unexpected reserved keyword "await" for modules or async function bodies'
+  })
+});
+
+describe('other valid types like namepaths do not pass in name parser', () => {
+  testFixture({
+    input: 'foo.test',
+    parseName: true,
+    error: "The parsing ended early. The next token was: '.' with value '.'"
+  })
+})

--- a/test/fixtures/typescript/parseNamePath.spec.ts
+++ b/test/fixtures/typescript/parseNamePath.spec.ts
@@ -1,0 +1,91 @@
+import { testFixture } from '../Fixture.js'
+
+describe('property named test', () => {
+  testFixture({
+    input: 'foo.test',
+    modes: ['jsdoc', 'closure', 'typescript'],
+    parseNamePath: true,
+    expected: {
+      type: 'JsdocTypeNamePath',
+      left: {
+        type: 'JsdocTypeName',
+        value: 'foo'
+      },
+      right: {
+        type: 'JsdocTypeProperty',
+        value: 'test',
+        meta: {
+          quote: undefined
+        }
+      },
+      pathType: 'property'
+    }
+  })
+})
+
+describe('property with reserved word', () => {
+  testFixture({
+    input: 'foo.continue',
+    parseNamePath: true,
+    extraParseArgs: {
+      module: false,
+      strictMode: false,
+      asyncFunctionBody: false
+    },
+    error: 'Unexpected reserved keyword "continue"'
+  })
+})
+
+describe('properties with special characters', () => {
+  testFixture({
+    input: 'foo#test~another',
+    modes: ['jsdoc', 'closure', 'typescript'],
+    parseNamePath: true,
+    expected: {
+      type: 'JsdocTypeNamePath',
+      left: {
+        left: {
+          type: 'JsdocTypeName',
+          value: 'foo'
+        },
+        pathType: 'instance',
+        right: {
+          meta: {
+            quote: undefined
+          },
+          type: 'JsdocTypeProperty',
+          value: 'test'
+        },
+        type: 'JsdocTypeNamePath'
+      },
+      right: {
+        type: 'JsdocTypeProperty',
+        value: 'another',
+        meta: {
+          quote: undefined
+        }
+      },
+      pathType: 'inner'
+    }
+  })
+})
+
+describe('parses simple name as namepath', () => {
+  testFixture({
+    input: 'foo',
+    modes: ['jsdoc', 'closure', 'typescript'],
+    parseNamePath: true,
+    expected: {
+      type: 'JsdocTypeName',
+      value: 'foo'
+    }
+  })
+});
+
+describe('other valid types like number do not pass in namePath parser', () => {
+  testFixture({
+    input: '12345',
+    parseNamePath: true,
+    error: "No parslet found for token: 'Number' with value '12345'"
+  })
+})


### PR DESCRIPTION
feat: `parseNamePath` and `parseName`; add `parse` options (`strictMode`, `module`, `asyncFunctionBody`)