### PR TITLE
feat(`parseNamePath`): allow parsing of special namepaths by option

### DIFF
--- a/src/grammars/closureGrammar.ts
+++ b/src/grammars/closureGrammar.ts
@@ -15,6 +15,8 @@ import { createSpecialNamePathParslet } from '../parslets/SpecialNamePathParslet
 import { createNamePathParslet } from '../parslets/NamePathParslet.js'
 import { symbolParslet } from '../parslets/SymbolParslet.js'
 import { createObjectFieldParslet } from '../parslets/ObjectFieldParslet.js'
+import { genericParslet } from '../parslets/GenericParslet.js'
+import { arrayBracketsParslet } from '../parslets/ArrayBracketsParslet.js'
 
 const objectFieldGrammar: Grammar = [
   createNameParslet({
@@ -75,6 +77,8 @@ export const closureGrammar = [
 ]
 
 export const closureNameGrammar = [
+  genericParslet,
+  arrayBracketsParslet,
   createNameParslet({
     allowedAdditionalTokens: [
       'module', 'keyof', 'event', 'external',
@@ -84,6 +88,8 @@ export const closureNameGrammar = [
 ]
 
 export const closureNamePathGrammar = [
+  genericParslet,
+  arrayBracketsParslet,
   createNameParslet({
     allowedAdditionalTokens: [
       'module', 'keyof', 'event', 'external',

--- a/src/grammars/closureGrammar.ts
+++ b/src/grammars/closureGrammar.ts
@@ -103,3 +103,11 @@ export const closureNamePathGrammar = [
     pathGrammar
   })
 ]
+
+export const closureNamePathSpecialGrammar = [
+  createSpecialNamePathParslet({
+    allowedTypes: ['module'],
+    pathGrammar
+  }),
+  ...closureNamePathGrammar
+]

--- a/src/grammars/jsdocGrammar.ts
+++ b/src/grammars/jsdocGrammar.ts
@@ -12,6 +12,7 @@ import { createNamePathParslet } from '../parslets/NamePathParslet.js'
 import { createObjectParslet } from '../parslets/ObjectParslet.js'
 import { createObjectFieldParslet } from '../parslets/ObjectFieldParslet.js'
 import { createKeyValueParslet } from '../parslets/KeyValueParslet.js'
+import { genericParslet } from '../parslets/GenericParslet.js'
 import type { TokenType } from '../lexer/Token.js'
 
 const jsdocBaseGrammar = [
@@ -74,12 +75,16 @@ const baseNameTokens: TokenType[] = [
 ]
 
 export const jsdocNameGrammar = [
+  genericParslet,
+  arrayBracketsParslet,
   createNameParslet({
     allowedAdditionalTokens: baseNameTokens
   })
 ]
 
 export const jsdocNamePathGrammar = [
+  genericParslet,
+  arrayBracketsParslet,
   createNameParslet({
     allowedAdditionalTokens: [
       ...baseNameTokens,

--- a/src/grammars/jsdocGrammar.ts
+++ b/src/grammars/jsdocGrammar.ts
@@ -98,3 +98,11 @@ export const jsdocNamePathGrammar = [
     pathGrammar
   })
 ]
+
+export const jsdocNamePathSpecialGrammar = [
+  createSpecialNamePathParslet({
+    allowedTypes: ['module', 'external', 'event'],
+    pathGrammar
+  }),
+  ...jsdocNamePathGrammar
+]

--- a/src/grammars/typescriptGrammar.ts
+++ b/src/grammars/typescriptGrammar.ts
@@ -138,3 +138,11 @@ export const typescriptNamePathGrammar = [
     pathGrammar
   })
 ]
+
+export const typescriptNamePathSpecialGrammar = [
+  createSpecialNamePathParslet({
+    allowedTypes: ['module'],
+    pathGrammar
+  }),
+  ...typescriptNamePathGrammar
+]

--- a/src/grammars/typescriptGrammar.ts
+++ b/src/grammars/typescriptGrammar.ts
@@ -29,6 +29,7 @@ import { objectSquaredPropertyParslet } from '../parslets/ObjectSquaredPropertyP
 import { readonlyArrayParslet } from '../parslets/ReadonlyArrayParslet.js'
 import { conditionalParslet } from '../parslets/ConditionalParslet.js'
 import { templateLiteralParslet } from '../parslets/TemplateLiteralParslet.js'
+import { genericParslet } from '../parslets/GenericParslet.js'
 
 const objectFieldGrammar: Grammar = [
   functionPropertyParslet,
@@ -107,6 +108,8 @@ export const typescriptGrammar: Grammar = [
 ]
 
 export const typescriptNameGrammar = [
+  genericParslet,
+  arrayBracketsParslet,
   createNameParslet({
     allowedAdditionalTokens: [
       // Cannot be JavaScript reserved word like `typeof`
@@ -117,6 +120,8 @@ export const typescriptNameGrammar = [
 ]
 
 export const typescriptNamePathGrammar = [
+  genericParslet,
+  arrayBracketsParslet,
   createNameParslet({
     allowedAdditionalTokens: [
       'typeof', 'in',

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,7 +1,16 @@
 import { Parser } from './Parser.js'
-import { jsdocGrammar, jsdocNamePathGrammar, jsdocNameGrammar } from './grammars/jsdocGrammar.js'
-import { closureGrammar, closureNamePathGrammar, closureNameGrammar } from './grammars/closureGrammar.js'
-import { typescriptGrammar, typescriptNamePathGrammar, typescriptNameGrammar } from './grammars/typescriptGrammar.js'
+import {
+  jsdocGrammar, jsdocNamePathGrammar,
+  jsdocNamePathSpecialGrammar, jsdocNameGrammar
+} from './grammars/jsdocGrammar.js'
+import {
+  closureGrammar, closureNamePathGrammar,
+  closureNamePathSpecialGrammar, closureNameGrammar
+} from './grammars/closureGrammar.js'
+import {
+  typescriptGrammar, typescriptNamePathGrammar,
+  typescriptNamePathSpecialGrammar, typescriptNameGrammar
+} from './grammars/typescriptGrammar.js'
 import { assertResultIsNotReservedWord } from './assertTypes.js'
 import type { RootResult } from './result/RootResult.js'
 import { Lexer } from './lexer/Lexer.js'
@@ -112,16 +121,26 @@ export function tryParse (
  * @param mode
  */
 export function parseNamePath (
-  expression: string, mode: ParseMode
+  expression: string, mode: ParseMode, {
+    includeSpecial = false
+  }: {
+    includeSpecial?: boolean
+  } = {}
 ): RootResult {
   switch (mode) {
     case 'closure':
-      return (new Parser(closureNamePathGrammar, Lexer.create(looseRules, expression))).parse()
+      return (new Parser(
+        includeSpecial ? closureNamePathSpecialGrammar : closureNamePathGrammar,
+        Lexer.create(looseRules, expression)
+      )).parse()
     case 'jsdoc':
-      return (new Parser(jsdocNamePathGrammar, Lexer.create(looseRules, expression))).parse()
+      return (new Parser(
+        includeSpecial ? jsdocNamePathSpecialGrammar : jsdocNamePathGrammar,
+        Lexer.create(looseRules, expression)
+      )).parse()
     case 'typescript': {
       return (new Parser(
-        typescriptNamePathGrammar,
+        includeSpecial ? typescriptNamePathSpecialGrammar : typescriptNamePathGrammar,
         Lexer.create(rules, expression)
       )).parse()
     }

--- a/test/fixtures/Fixture.ts
+++ b/test/fixtures/Fixture.ts
@@ -43,7 +43,8 @@ interface BaseFixture {
 interface extraParseArgs {
   module?: boolean,
   strictMode?: boolean,
-  asyncFunctionBody?: boolean
+  asyncFunctionBody?: boolean,
+  includeSpecial?: boolean
 }
 
 type SuccessFixture = BaseFixture & {
@@ -78,7 +79,10 @@ function testParser (mode: ParseMode, fixture: Fixture): RootResult | undefined 
       it(`is parsed in '${mode}' mode`, () => {
         const result = fixture.parseNamePath ? parseNamePath(
           fixture.input,
-          mode
+          mode,
+          {
+            ...fixture.extraParseArgs
+          }
         ) : fixture.parseName ? parseName(fixture.input, mode) : parse(
           fixture.input,
           mode,
@@ -93,7 +97,10 @@ function testParser (mode: ParseMode, fixture: Fixture): RootResult | undefined 
       try {
         return fixture.parseNamePath ? parseNamePath(
           fixture.input,
-          mode
+          mode,
+          {
+            ...fixture.extraParseArgs
+          }
         ) : fixture.parseName ? parseName(fixture.input, mode) :parse(
           fixture.input,
           mode,
@@ -113,7 +120,10 @@ function testParser (mode: ParseMode, fixture: Fixture): RootResult | undefined 
           if (fixture.parseNamePath) {
             parseNamePath(
               fixture.input,
-              mode
+              mode,
+              {
+                ...fixture.extraParseArgs
+              }
             )
           } else if (fixture.parseName) {
             parseName(fixture.input, mode)
@@ -131,7 +141,10 @@ function testParser (mode: ParseMode, fixture: Fixture): RootResult | undefined 
           if (fixture.parseNamePath) {
             parseNamePath(
               fixture.input,
-              mode
+              mode,
+              {
+                ...fixture.extraParseArgs
+              }
             )
           } else if (fixture.parseName) {
             parseName(fixture.input, mode)

--- a/test/fixtures/misc/parseName.spec.ts
+++ b/test/fixtures/misc/parseName.spec.ts
@@ -12,6 +12,31 @@ describe('parses simple name', () => {
   })
 });
 
+describe('parses name with generic', () => {
+  testFixture({
+    input: 'foo<T>',
+    modes: ['jsdoc', 'closure', 'typescript'],
+    parseName: true,
+    expected: {
+      elements: [
+        {
+          type: 'JsdocTypeName',
+          value: 'T'
+        }
+      ],
+      left: {
+        type: 'JsdocTypeName',
+        value: 'foo'
+      },
+      meta: {
+        brackets: 'angle',
+        dot: false
+      },
+      type: 'JsdocTypeGeneric'
+    }
+  })
+})
+
 describe('other valid types like namepaths do not pass in name parser', () => {
   testFixture({
     input: 'foo.test',

--- a/test/fixtures/misc/parseNamePath.spec.ts
+++ b/test/fixtures/misc/parseNamePath.spec.ts
@@ -116,6 +116,47 @@ describe('parses namepath with array generic', () => {
   })
 })
 
+describe('parses special namepath', () => {
+  testFixture({
+    input: 'module:abc/def~ghi#jkl',
+    modes: ['jsdoc', 'closure', 'typescript'],
+    parseNamePath: true,
+    extraParseArgs: {
+      includeSpecial: true
+    },
+    expected: {
+      type: 'JsdocTypeNamePath',
+      left: {
+        type: 'JsdocTypeNamePath',
+        left: {
+          type: 'JsdocTypeSpecialNamePath',
+          value: 'abc/def',
+          specialType: 'module',
+          meta: {
+            quote: undefined
+          }
+        },
+        right: {
+          type: 'JsdocTypeProperty',
+          value: 'ghi',
+          meta: {
+            quote: undefined
+          }
+        },
+        pathType: 'inner'
+      },
+      right: {
+        type: 'JsdocTypeProperty',
+        value: 'jkl',
+        meta: {
+          quote: undefined
+        }
+      },
+      pathType: 'instance'
+    }
+  })
+})
+
 describe('parses simple name as namepath', () => {
   testFixture({
     input: 'foo',

--- a/test/fixtures/misc/parseNamePath.spec.ts
+++ b/test/fixtures/misc/parseNamePath.spec.ts
@@ -80,6 +80,42 @@ describe('properties with special characters', () => {
   })
 })
 
+describe('parses namepath with array generic', () => {
+  testFixture({
+    input: 'employees[].name',
+    modes: ['jsdoc', 'closure', 'typescript'],
+    parseNamePath: true,
+    expected: {
+      left: {
+        elements: [
+          {
+            type: 'JsdocTypeName',
+            value: 'employees'
+          }
+        ],
+        left: {
+          type: 'JsdocTypeName',
+          value: 'Array'
+        },
+        meta: {
+          brackets: 'square',
+          dot: false
+        },
+        type: 'JsdocTypeGeneric'
+      },
+      pathType: 'property',
+      right: {
+        meta: {
+          quote: undefined
+        },
+        type: 'JsdocTypeProperty',
+        value: 'name'
+      },
+      type: 'JsdocTypeNamePath'
+    }
+  })
+})
+
 describe('parses simple name as namepath', () => {
   testFixture({
     input: 'foo',


### PR DESCRIPTION
- fix: add generic parsing to name/namepaths
- feat(`parseNamePath`): allow parsing of special namepaths by option