### PR TITLE
feat(stringify): add `postColonSpacing`, `postKeySpacing`, and `postOptionalSpacing` options to object fields

### DIFF
--- a/src/result/NonRootResult.ts
+++ b/src/result/NonRootResult.ts
@@ -32,7 +32,10 @@ export interface ObjectFieldResult {
   optional: boolean
   readonly: boolean
   meta: {
-    quote: QuoteStyle | undefined
+    quote: QuoteStyle | undefined,
+    postColonSpacing?: string
+    postKeySpacing?: string
+    postOptionalSpacing?: string
   }
 }
 

--- a/src/transforms/stringify.ts
+++ b/src/transforms/stringify.ts
@@ -119,14 +119,17 @@ export function stringifyRules ({
         text += transform(result.key)
       }
 
+      text += result.meta.postKeySpacing ?? ''
+
       if (!optionalBeforeParentheses && result.optional) {
         text += '?'
+        text += result.meta.postOptionalSpacing ?? ''
       }
 
       if (result.right === undefined) {
         return text
       } else {
-        return text + `: ${transform(result.right)}`
+        return text + `:${result.meta.postColonSpacing ?? ' '}${transform(result.right)}`
       }
     },
 

--- a/test/stringify.spec.ts
+++ b/test/stringify.spec.ts
@@ -458,6 +458,37 @@ describe('`stringifyRules`', () => {
     expect(result).to.equal(expected)
   });
 
+  it('should stringify an object field', () => {
+    const expected = '{a ? :string}'
+    const rootResult: RootResult = {
+      type: 'JsdocTypeObject',
+      elements: [
+        {
+          type: 'JsdocTypeObjectField',
+          key: 'a',
+          optional: true,
+          readonly: false,
+          right: {
+            type: 'JsdocTypeName',
+            value: 'string'
+          },
+          meta: {
+            quote: undefined,
+            postColonSpacing: '',
+            postKeySpacing: ' ',
+            postOptionalSpacing: ' '
+          }
+        }
+      ],
+      meta: {
+        separator: 'comma'
+      }
+    }
+
+    const result = stringify(rootResult)
+    expect(result).to.equal(expected)
+  });
+
   it('should stringify `right` undefined `JsdocTypeKeyValue`', () => {
     const expected = 'a'
     const nonRootResult: KeyValueResult = {


### PR DESCRIPTION
feat(stringify): add `postColonSpacing`, `postKeySpacing`, and `postOptionalSpacing` options to object fields